### PR TITLE
Fix scrollable content size is ambiguous in wallet log

### DIFF
--- a/Decred Wallet/Features/More/More Features/Debug/WalletLogViewController.swift
+++ b/Decred Wallet/Features/More/More Features/Debug/WalletLogViewController.swift
@@ -55,7 +55,7 @@ class WalletLogViewController: UIViewController {
     @objc func copyLog() -> Void {
         DispatchQueue.main.async {
             UIPasteboard.general.string = self.logTextView.text
-            Utils.showBanner(in: self.view.subviews.first!, type: .success, text: LocalizedStrings.walletLogCopied)
+            Utils.showBanner(in: self.view, type: .success, text: LocalizedStrings.walletLogCopied)
         }
     }
     


### PR DESCRIPTION
fix the error after copying can't scroll in wallet log