### PR TITLE
Remove sync check when creating or deleting wallet

### DIFF
--- a/Decred Wallet/Features/Wallets/WalletSettingsViewController.swift
+++ b/Decred Wallet/Features/Wallets/WalletSettingsViewController.swift
@@ -94,10 +94,6 @@ class WalletSettingsViewController: UIViewController {
     }
 
     @IBAction func removeWalletFromDevice(_ sender: Any) {
-        if WalletLoader.shared.multiWallet.isConnectedToDecredNetwork() {
-            Utils.showBanner(in: self.view, type: .error, text: LocalizedStrings.disconnectDeleteWallet)
-            return
-        }
         self.showRemoveWalletWarning() { ok in
             guard ok else { return }
             

--- a/Decred Wallet/Features/Wallets/WalletsViewController.swift
+++ b/Decred Wallet/Features/Wallets/WalletsViewController.swift
@@ -57,9 +57,6 @@ class WalletsViewController: UIViewController {
         if WalletLoader.shared.multiWallet.openedWalletsCount() >= numberOfwalletAllowed {
             SimpleAlertDialog.show(sender: self, message: LocalizedStrings.walletsLimitError, okButtonText: LocalizedStrings.ok)
             return
-        } else if WalletLoader.shared.multiWallet.isConnectedToDecredNetwork() {
-            Utils.showBanner(in: self.view, type: .error, text: LocalizedStrings.disconnectAddWallet)
-            return
         }
         
         let alertController = UIAlertController(title: nil,


### PR DESCRIPTION
This pr removes the conditions that require users to cancel sync before creating/deleting a wallet. The cancellation is now handled in dcrlibwallet