### PR TITLE
label mixed transaction as 'mix'

### DIFF
--- a/Decred Wallet/DcrlibwalletTypes/Transaction.swift
+++ b/Decred Wallet/DcrlibwalletTypes/Transaction.swift
@@ -25,6 +25,7 @@ struct Transaction: Codable {
     
     var direction: Int32
     var amount: Int64
+    var mixDenom: Int64
     var inputs: [TxInput]
     var outputs: [TxOutput]
     
@@ -53,6 +54,8 @@ struct Transaction: Codable {
         
         case direction, amount, inputs, outputs
         
+        case mixDenom = "mix_denom"
+        
         case voteVersion = "vote_version"
         case lastBlockValid = "last_block_valid"
         case voteBits = "vote_bits"
@@ -78,6 +81,7 @@ struct Transaction: Codable {
         
         self.direction = try! values.decode(Int32.self, forKey: .direction)
         self.amount = try! values.decode(Int64.self, forKey: .amount)
+        self.mixDenom = try! values.decode(Int64.self, forKey: .mixDenom)
         self.inputs = try! values.decode([TxInput].self, forKey: .inputs)
         self.outputs = try! values.decode([TxOutput].self, forKey: .outputs)
         
@@ -92,6 +96,10 @@ struct Transaction: Codable {
     
     var dcrAmount: NSDecimalNumber {
         return Decimal(DcrlibwalletAmountCoin(self.amount)) as NSDecimalNumber
+    }
+    
+    var dcrMixDenom: NSDecimalNumber {
+        return Decimal(DcrlibwalletAmountCoin(self.mixDenom)) as NSDecimalNumber
     }
     
     var dcrVoteReward: NSDecimalNumber {

--- a/Decred Wallet/Features/TransactionDetails/TransactionDetailsViewController.swift
+++ b/Decred Wallet/Features/TransactionDetails/TransactionDetailsViewController.swift
@@ -187,8 +187,14 @@ class TransactionDetailsViewController: UIViewController {
     }
 
     private func prepareTxOverview() {
-        let attributedAmountString = NSMutableAttributedString(string: (transaction.type == DcrlibwalletTxTypeRegular && transaction.direction == DcrlibwalletTxDirectionSent) ? "-" : "")
-        attributedAmountString.append(Utils.getAttributedString(str: transaction.dcrAmount.round(8).description, siz: 20.0, TexthexColor: UIColor.appColors.darkBlue))
+        let attributedAmountString: NSMutableAttributedString
+        if transaction.isMixed {
+            attributedAmountString = Utils.getAttributedString(str: transaction.dcrMixDenom.round(8).description, siz: 20.0, TexthexColor: UIColor.appColors.darkBlue)
+        } else {
+            attributedAmountString = NSMutableAttributedString(string: (transaction.type == DcrlibwalletTxTypeRegular && transaction.direction == DcrlibwalletTxDirectionSent) ? "-" : "")
+            attributedAmountString.append(Utils.getAttributedString(str: transaction.dcrAmount.round(8).description, siz: 20.0, TexthexColor: UIColor.appColors.darkBlue))
+        }
+        
         self.txOverview.txAmount = attributedAmountString
 
         self.txOverview.date = Utils.formatDateTime(timestamp: transaction.timestamp)

--- a/Decred Wallet/Features/Transactions/TransactionTableViewCell.swift
+++ b/Decred Wallet/Features/Transactions/TransactionTableViewCell.swift
@@ -65,7 +65,7 @@ class TransactionTableViewCell: UITableViewCell {
     func displayRegularTxInfo(_ transaction: Transaction) {
         let amountString = Utils.getAttributedString(str: transaction.dcrAmount.round(8).description, siz: 13.0, TexthexColor: UIColor.appColors.darkBlue)
         if transaction.isMixed {
-            let attributedString = NSMutableAttributedString(string: LocalizedStrings.mixed)
+            let attributedString = NSMutableAttributedString(string: LocalizedStrings.mix)
             self.txAmountOrTicketStatusLabel.attributedText = attributedString
             self.txTypeIconImageView?.image = UIImage(named: "ic_send")
         } else {

--- a/Decred Wallet/Utils/LocalizedStrings.swift
+++ b/Decred Wallet/Utils/LocalizedStrings.swift
@@ -539,4 +539,5 @@ struct LocalizedStrings {
     static let continueText = NSLocalizedString("continueText", comment: "")
     static let unlockToStartMixing = NSLocalizedString("unlockToStartMixing", comment: "")
     static let mixed = NSLocalizedString("mixed", comment: "")
+    static let mix = NSLocalizedString("mix", comment: "")
 }

--- a/Decred Wallet/en.lproj/Localizable.strings
+++ b/Decred Wallet/en.lproj/Localizable.strings
@@ -583,3 +583,4 @@
 "continueText" = "Continue";
 "unlockToStartMixing" = "Unlock your wallet to start mixing";
 "mixed" = "Mixed";
+"mix" = "Mix";


### PR DESCRIPTION
Resolves https://github.com/planetdecred/dcrios/issues/756

- remove double negative sign from the amount and set it as the mix denomination
- label mixed transaction as 'mix'