### PR TITLE
format mixer balances and round to 8dp

### DIFF
--- a/Decred Wallet/Features/Privacy/PrivacyViewController.swift
+++ b/Decred Wallet/Features/Privacy/PrivacyViewController.swift
@@ -207,8 +207,8 @@ class PrivacyViewController: UIViewController {
             let unmixedBalance = try wallet?.getAccountBalance(Int32(unmixedAccountNumber))
             let mixedBalance = try wallet?.getAccountBalance(Int32(mixedAccountNumber))
             DispatchQueue.main.async {
-                self.unmixedBalance.text = "\(unmixedBalance?.dcrTotal ?? 0.00) DCR"
-                self.mixedBalance.text = "\(mixedBalance?.dcrTotal ?? 0.00) DCR"
+                self.unmixedBalance.text = Utils.amountAsAttributedString(amount: unmixedBalance?.dcrTotal, smallerTextSize: 15.0).string
+                self.mixedBalance.text = Utils.amountAsAttributedString(amount: mixedBalance?.dcrTotal, smallerTextSize: 15.0).string
             }
         } catch {
             DispatchQueue.main.async {


### PR DESCRIPTION
Resolves #761 

This PR formats the mixer balances displayed on the privacy page and rounds them to 8dp, to prevent the user getting a scientific notation value as the mixer balance