### PR TITLE
implement account filter operation on privacy setup

### DIFF
--- a/Decred Wallet.xcodeproj/project.pbxproj
+++ b/Decred Wallet.xcodeproj/project.pbxproj
@@ -1,2139 +1,2139 @@
 // !$*UTF8*$!
 {
-    archiveVersion = 1;
-    classes = {
-    };
-    objectVersion = 51;
-    objects = {
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 51;
+	objects = {
 
 /* Begin PBXBuildFile section */
-        100B122923E9EEAC005636A7 /* TransactionTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 100B122523E9EEAC005636A7 /* TransactionTableViewCell.xib */; };
-        100B122A23E9EEAC005636A7 /* TransactionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100B122623E9EEAC005636A7 /* TransactionTableViewCell.swift */; };
-        100B122B23E9EEAC005636A7 /* Transactions.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 100B122723E9EEAC005636A7 /* Transactions.storyboard */; };
-        100B122C23E9EEAC005636A7 /* TransactionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100B122823E9EEAC005636A7 /* TransactionsViewController.swift */; };
-        100B122E23E9EECB005636A7 /* RestoreExistingWalletSuccessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100B122D23E9EECB005636A7 /* RestoreExistingWalletSuccessViewController.swift */; };
-        102AFAC423AA2B4D007E2EBD /* ProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102AFAC323AA2B4D007E2EBD /* ProgressView.swift */; };
-        102D724B23ED5271002DCAF2 /* TransactionDetailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102D724723ED5271002DCAF2 /* TransactionDetailCell.swift */; };
-        10341E0723CBBB700055DFDE /* SeedBackupSuccessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10341E0023CBBB700055DFDE /* SeedBackupSuccessViewController.swift */; };
-        10341E0823CBBB700055DFDE /* SeedWordsDisplayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10341E0123CBBB700055DFDE /* SeedWordsDisplayViewController.swift */; };
-        10341E0923CBBB700055DFDE /* SeedBackupVerifyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10341E0223CBBB700055DFDE /* SeedBackupVerifyViewController.swift */; };
-        10341E0A23CBBB700055DFDE /* SeedBackupVerifyTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10341E0323CBBB700055DFDE /* SeedBackupVerifyTableViewCell.swift */; };
-        10341E0B23CBBB700055DFDE /* SeedWordsDisplayTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10341E0423CBBB700055DFDE /* SeedWordsDisplayTableViewCell.swift */; };
-        10341E0C23CBBB700055DFDE /* SeedBackup.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 10341E0523CBBB700055DFDE /* SeedBackup.storyboard */; };
-        10341E0D23CBBB700055DFDE /* SeedBackupReminderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10341E0623CBBB700055DFDE /* SeedBackupReminderViewController.swift */; };
-        10341E0F23CBBB7E0055DFDE /* Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10341E0E23CBBB7E0055DFDE /* Label.swift */; };
-        1034D5CF24113BF10009576C /* SimpleAlertDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1034D5CE24113BF10009576C /* SimpleAlertDialog.swift */; };
-        103BE67E240D1F9E007910DA /* WalletSelectorCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103BE67D240D1F9E007910DA /* WalletSelectorCollectionViewCell.swift */; };
-        105836B823EACD390030FDF2 /* ReceiveViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105836B623EACD390030FDF2 /* ReceiveViewController.swift */; };
-        105836B923EACD390030FDF2 /* Receive.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 105836B723EACD390030FDF2 /* Receive.storyboard */; };
-        108A2E7423DE311900B13A22 /* SelfSizedTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 108A2E7323DE311900B13A22 /* SelfSizedTableView.swift */; };
-        10945CDA23F3DB0C00BBE242 /* TransactionOverviewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10945CD923F3DB0C00BBE242 /* TransactionOverviewCell.swift */; };
-        10B7818223F066DA00AD2709 /* TransactionInputDetailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10B7818023F066DA00AD2709 /* TransactionInputDetailCell.swift */; };
-        10B7818523F0693C00AD2709 /* TransactionOutputDetailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10B7818423F0693C00AD2709 /* TransactionOutputDetailCell.swift */; };
-        10BA77992390059F00B67446 /* TabMenuItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10BA77982390059F00B67446 /* TabMenuItemView.swift */; };
-        10C6610E23EC587B00754DED /* AccountSelectorDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C6610B23EC587B00754DED /* AccountSelectorDialog.swift */; };
-        10C6610F23EC587B00754DED /* AccountSelectorTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 10C6610C23EC587B00754DED /* AccountSelectorTableViewCell.xib */; };
-        10C6611023EC587B00754DED /* AccountSelectorTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C6610D23EC587B00754DED /* AccountSelectorTableViewCell.swift */; };
-        10D9FB9323C3956300CBF216 /* FloatingPlaceholderTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D9FB8E23C3956200CBF216 /* FloatingPlaceholderTextField.swift */; };
-        10D9FB9623C3956300CBF216 /* FloatingPlaceholderLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D9FB9123C3956300CBF216 /* FloatingPlaceholderLabel.swift */; };
-        10FABE4B23C72D6800BC201B /* FloatingPlaceholderInputProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FABE4A23C72D6700BC201B /* FloatingPlaceholderInputProtocol.swift */; };
-        10FABE4F23C7303E00BC201B /* FloatingPlaceholderTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FABE4E23C7303E00BC201B /* FloatingPlaceholderTextView.swift */; };
-        10FABE5123C7307100BC201B /* FloatingPlaceholderBorderLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FABE5023C7307100BC201B /* FloatingPlaceholderBorderLayer.swift */; };
-        250D77BD23F2BF0F00CDC256 /* DecredAddressURI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 250D77BC23F2BF0F00CDC256 /* DecredAddressURI.swift */; };
-        2557E1892355C6FA00B6A1B7 /* NavigationMenuTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2557E1882355C6FA00B6A1B7 /* NavigationMenuTabBarController.swift */; };
-        2557E18B2355C9F000B6A1B7 /* CustomTabMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2557E18A2355C9F000B6A1B7 /* CustomTabMenuView.swift */; };
-        25751F532372C9460019F657 /* Dcrlibwallet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25751F522372C9460019F657 /* Dcrlibwallet.framework */; };
-        25A4331C2373D0330018FFCF /* SyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25A4331B2373D0330018FFCF /* SyncManager.swift */; };
-        25E63F4E23312B2C009CD53E /* NavMenuFloatingButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E63F4D23312B2B009CD53E /* NavMenuFloatingButtons.swift */; };
-        60778AE026274DA9006B1FC2 /* WalletMixerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60778ADF26274DA9006B1FC2 /* WalletMixerCell.swift */; };
-        6004FFB825CC5D0100D5A25C /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6004FFB725CC5D0100D5A25C /* LoadingView.swift */; };
-        6007D38B24F406AA000EC5CB /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6007D38A24F406AA000EC5CB /* Response.swift */; };
-        6007D38D24F42089000EC5CB /* PoliteiaNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6007D38C24F42089000EC5CB /* PoliteiaNotification.swift */; };
-        60C7E54124ED8738009E4569 /* PlainHorizontalProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C7E54024ED8738009E4569 /* PlainHorizontalProgressBar.swift */; };
-        60C7E54624ED88B8009E4569 /* Politeia.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 60C7E54324ED88B8009E4569 /* Politeia.storyboard */; };
-        60C7E54724ED88B8009E4569 /* PoliteiaTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C7E54424ED88B8009E4569 /* PoliteiaTableViewCell.swift */; };
-        60C7E54824ED88B8009E4569 /* PoliteiaController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C7E54524ED88B8009E4569 /* PoliteiaController.swift */; };
-        60C7E54B24ED88F0009E4569 /* PoliteiaStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C7E54924ED88F0009E4569 /* PoliteiaStatus.swift */; };
-        60C7E54C24ED88F0009E4569 /* Politeia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C7E54A24ED88F0009E4569 /* Politeia.swift */; };
-        60DFF5D124F75D4500624161 /* PoliteiaDetailController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DFF5D024F75D4500624161 /* PoliteiaDetailController.swift */; };
-        60E853A025B324C800E4CFDD /* ConnectedPeerViewcontroller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E8539F25B324C800E4CFDD /* ConnectedPeerViewcontroller.swift */; };
-        60E853A425B4805200E4CFDD /* PeerInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E853A325B4805200E4CFDD /* PeerInfo.swift */; };
-        60E853A825B48F9800E4CFDD /* ConnectedPeerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E853A725B48F9800E4CFDD /* ConnectedPeerTableViewCell.swift */; };
-        AD24C23D2343E445009583C9 /* NotificationsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD24C23C2343E445009583C9 /* NotificationsManager.swift */; };
-        B164982429AEDD7AF8C8782C /* Pods_Decred_Wallet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9714AB438E597D403032748 /* Pods_Decred_Wallet.framework */; };
-        B304B39423F202A400B81798 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B304B39323F202A400B81798 /* Settings.swift */; };
-        B32EB42E23EEA24000E43D4F /* AccountDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32EB42D23EEA24000E43D4F /* AccountDetailsViewController.swift */; };
-        B3456D2523D91CF600B04860 /* RoundedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3456D2423D91CF600B04860 /* RoundedView.swift */; };
-        B34A2F8F23E8E90500B8BC01 /* WalletSyncDetailsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34A2F8E23E8E90500B8BC01 /* WalletSyncDetailsTableViewCell.swift */; };
-        B34A2F9123E8ED1500B8BC01 /* MultiWalletSyncDetailsLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34A2F9023E8ED1500B8BC01 /* MultiWalletSyncDetailsLoader.swift */; };
-        B35C55D8232FED610006A765 /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35C55D7232FED610006A765 /* Transaction.swift */; };
-        B3635B82229FE5870052EB4D /* QRImageScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3635B81229FE5870052EB4D /* QRImageScanner.swift */; };
-        B36EFD362298617C002753B2 /* UIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36EFD352298617C002753B2 /* UIButton.swift */; };
-        B379BA6523E2A2F1002CA92E /* SingleToMultiWalletMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B379BA6423E2A2F1002CA92E /* SingleToMultiWalletMigration.swift */; };
-        B37AD0A32408870B00C83D80 /* WalletAccountView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B37AD0A22408870B00C83D80 /* WalletAccountView.xib */; };
-        B37AD0A524088A6700C83D80 /* WalletAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37AD0A424088A6700C83D80 /* WalletAccountView.swift */; };
-        B3967B3D22A75BD400E14432 /* UITableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3967B3C22A75BD400E14432 /* UITableView.swift */; };
-        B39BDC4D228F798300F3FB55 /* BuildConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39BDC4C228F798300F3FB55 /* BuildConfig.swift */; };
-        B3A3EF8622936BFE00008A4E /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A3EF8522936BFE00008A4E /* Reachability.swift */; };
-        B3A3EF88229375D100008A4E /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A3EF87229375D100008A4E /* Date.swift */; };
-        B3A3EF922295956300008A4E /* SendViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A3EF912295956300008A4E /* SendViewController.swift */; };
-        B3A8E80A23E593720094957B /* CheckableListOptionTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B3A8E80923E593720094957B /* CheckableListOptionTableViewCell.xib */; };
-        B3B46993228F0C2E00A68EDD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46992228F0C2E00A68EDD /* AppDelegate.swift */; };
-        B3B4699A228F0C2E00A68EDD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B3B46999228F0C2E00A68EDD /* Assets.xcassets */; };
-        B3B4699D228F0C2E00A68EDD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B3B4699B228F0C2E00A68EDD /* LaunchScreen.storyboard */; };
-        B3B469FA228F0F2700A68EDD /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469A8228F0F2600A68EDD /* UIColor.swift */; };
-        B3B469FB228F0F2700A68EDD /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469A9228F0F2600A68EDD /* Extensions.swift */; };
-        B3B469FC228F0F2700A68EDD /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469AA228F0F2600A68EDD /* String.swift */; };
-        B3B469FD228F0F2700A68EDD /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469AB228F0F2600A68EDD /* UIViewController.swift */; };
-        B3B469FE228F0F2700A68EDD /* Button.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469AD228F0F2600A68EDD /* Button.swift */; };
-        B3B46A00228F0F2700A68EDD /* inconsolata_regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469B1228F0F2600A68EDD /* inconsolata_regular.ttf */; };
-        B3B46A01228F0F2700A68EDD /* SourceSansPro-BlackItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469B3228F0F2600A68EDD /* SourceSansPro-BlackItalic.ttf */; };
-        B3B46A02228F0F2700A68EDD /* SourceSansPro-SemiBoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469B4228F0F2600A68EDD /* SourceSansPro-SemiBoldItalic.ttf */; };
-        B3B46A03228F0F2700A68EDD /* SourceSansPro-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469B5228F0F2600A68EDD /* SourceSansPro-Regular.ttf */; };
-        B3B46A04228F0F2700A68EDD /* SourceSansPro-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469B6228F0F2600A68EDD /* SourceSansPro-Bold.ttf */; };
-        B3B46A05228F0F2700A68EDD /* SourceSansPro-LightItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469B7228F0F2600A68EDD /* SourceSansPro-LightItalic.ttf */; };
-        B3B46A06228F0F2700A68EDD /* SourceSansPro-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469B8228F0F2600A68EDD /* SourceSansPro-Light.ttf */; };
-        B3B46A07228F0F2700A68EDD /* SourceSansPro-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469B9228F0F2600A68EDD /* SourceSansPro-Black.ttf */; };
-        B3B46A08228F0F2700A68EDD /* SourceSansPro-ExtraLight.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469BA228F0F2600A68EDD /* SourceSansPro-ExtraLight.ttf */; };
-        B3B46A09228F0F2700A68EDD /* SourceSansPro-BoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469BB228F0F2600A68EDD /* SourceSansPro-BoldItalic.ttf */; };
-        B3B46A0A228F0F2700A68EDD /* SourceSansPro-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469BC228F0F2600A68EDD /* SourceSansPro-SemiBold.ttf */; };
-        B3B46A0B228F0F2700A68EDD /* SourceSansPro-ExtraLightItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469BD228F0F2600A68EDD /* SourceSansPro-ExtraLightItalic.ttf */; };
-        B3B46A0C228F0F2700A68EDD /* SourceSansPro-Italic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469BE228F0F2600A68EDD /* SourceSansPro-Italic.ttf */; };
-        B3B46A0D228F0F2700A68EDD /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469C0228F0F2600A68EDD /* Constants.swift */; };
-        B3B46A0E228F0F2700A68EDD /* wordlist.txt in Resources */ = {isa = PBXBuildFile; fileRef = B3B469C1228F0F2600A68EDD /* wordlist.txt */; };
-        B3B46A10228F0F2700A68EDD /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469C7228F0F2600A68EDD /* UIView.swift */; };
-        B3B46A11228F0F2700A68EDD /* UITableViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469C8228F0F2600A68EDD /* UITableViewExtension.swift */; };
-        B3B46A12228F0F2700A68EDD /* TextFieldDoneButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469C9228F0F2600A68EDD /* TextFieldDoneButton.swift */; };
-        B3B46A15228F0F2700A68EDD /* UIImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469CD228F0F2600A68EDD /* UIImageView.swift */; };
-        B3B46A17228F0F2700A68EDD /* ContouredButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469CF228F0F2600A68EDD /* ContouredButton.swift */; };
-        B3B46A18228F0F2700A68EDD /* DropDownSearchField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469D0228F0F2600A68EDD /* DropDownSearchField.swift */; };
-        B3B46A19228F0F2700A68EDD /* StartScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469D3228F0F2600A68EDD /* StartScreenViewController.swift */; };
-        B3B46A1B228F0F2700A68EDD /* SecurityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469D6228F0F2600A68EDD /* SecurityViewController.swift */; };
-        B3B46A1D228F0F2700A68EDD /* RequestPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469D8228F0F2600A68EDD /* RequestPasswordViewController.swift */; };
-        B3B46A1F228F0F2700A68EDD /* RequestPinViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469DA228F0F2600A68EDD /* RequestPinViewController.swift */; };
-        B3B46A20228F0F2700A68EDD /* PinPasswordStrength.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469DB228F0F2600A68EDD /* PinPasswordStrength.swift */; };
-        B3B46A21228F0F2700A68EDD /* SecurityCodeRequestBaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469DC228F0F2600A68EDD /* SecurityCodeRequestBaseViewController.swift */; };
-        B3B46A2E228F0F2700A68EDD /* MenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469EC228F0F2600A68EDD /* MenuItem.swift */; };
-        B3B46A32228F0F2700A68EDD /* OverviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469F1228F0F2600A68EDD /* OverviewViewController.swift */; };
-        B3B46A34228F0F2700A68EDD /* TransactionNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469F4228F0F2600A68EDD /* TransactionNotification.swift */; };
-        B3B46A36228F0F2700A68EDD /* WalletLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469F6228F0F2600A68EDD /* WalletLoader.swift */; };
-        B3B46A37228F0F2700A68EDD /* SpendingPinOrPassword.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469F7228F0F2600A68EDD /* SpendingPinOrPassword.swift */; };
-        B3B46A38228F0F2700A68EDD /* Dcrlibwallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469F8228F0F2600A68EDD /* Dcrlibwallet.swift */; };
-        B3B46A39228F0F2700A68EDD /* StartupPinOrPassword.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469F9228F0F2600A68EDD /* StartupPinOrPassword.swift */; };
-        B3B46A3F228F0F6700A68EDD /* bg-button@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = B3B46A3B228F0F6700A68EDD /* bg-button@3x.png */; };
-        B3B46A40228F0F6700A68EDD /* bg-button.png in Resources */ = {isa = PBXBuildFile; fileRef = B3B46A3C228F0F6700A68EDD /* bg-button.png */; };
-        B3B46A41228F0F6700A68EDD /* dcr-logo.png in Resources */ = {isa = PBXBuildFile; fileRef = B3B46A3D228F0F6700A68EDD /* dcr-logo.png */; };
-        B3B46A42228F0F6700A68EDD /* progress bar-1s-200px.gif in Resources */ = {isa = PBXBuildFile; fileRef = B3B46A3E228F0F6700A68EDD /* progress bar-1s-200px.gif */; };
-        B3B46A86228F0F7D00A68EDD /* DropMenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A49228F0F7B00A68EDD /* DropMenuButton.swift */; };
-        B3B46A87228F0F7D00A68EDD /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A4A228F0F7B00A68EDD /* Data.swift */; };
-        B3B46A88228F0F7D00A68EDD /* UIIMage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A4B228F0F7B00A68EDD /* UIIMage.swift */; };
-        B3B46A89228F0F7D00A68EDD /* keyPadButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A4C228F0F7B00A68EDD /* keyPadButton.swift */; };
-        B3B46A8A228F0F7D00A68EDD /* customUImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A4D228F0F7B00A68EDD /* customUImage.swift */; };
-        B3B46A8C228F0F7D00A68EDD /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A4F228F0F7B00A68EDD /* Utils.swift */; };
-        B3B46A8F228F0F7D00A68EDD /* ConfirmToSendFundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A54228F0F7B00A68EDD /* ConfirmToSendFundViewController.swift */; };
-        B3B46A97228F0F7D00A68EDD /* TransactionDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A5E228F0F7B00A68EDD /* TransactionDetailsViewController.swift */; };
-        B3B46A98228F0F7D00A68EDD /* TransactionDetails.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B3B46A5F228F0F7B00A68EDD /* TransactionDetails.storyboard */; };
-        B3B46A9A228F0F7D00A68EDD /* SettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A61228F0F7B00A68EDD /* SettingsController.swift */; };
-        B3B46A9B228F0F7D00A68EDD /* PeerSetTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A62228F0F7B00A68EDD /* PeerSetTableViewController.swift */; };
-        B3B46A9F228F0F7D00A68EDD /* WalletLogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A66228F0F7B00A68EDD /* WalletLogViewController.swift */; };
-        B3B46AA7228F0F7D00A68EDD /* CurrencyConversionOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A6F228F0F7B00A68EDD /* CurrencyConversionOptionsViewController.swift */; };
-        B3B46AAC228F0F7D00A68EDD /* RecoveryWalletSeedWordCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A75228F0F7C00A68EDD /* RecoveryWalletSeedWordCell.swift */; };
-        B3B46AB1228F0F7D00A68EDD /* SeedCheckActiveCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A7A228F0F7C00A68EDD /* SeedCheckActiveCellView.swift */; };
-        B3B46AB3228F0F7D00A68EDD /* ConfirmSeedViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A7C228F0F7C00A68EDD /* ConfirmSeedViewCell.swift */; };
-        B3B46AB6228F0F7D00A68EDD /* Storyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A7F228F0F7C00A68EDD /* Storyboard.swift */; };
-        B3B9432923E4D0B30088EC3E /* WalletSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B9432823E4D0B30088EC3E /* WalletSettingsViewController.swift */; };
-        B3C03B2323DD41EE00156D9F /* Wallets.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B3C03B2223DD41EE00156D9F /* Wallets.storyboard */; };
-        B3C0D4AF23DF9C45002D984F /* Security.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C0D4AE23DF9C45002D984F /* Security.swift */; };
-        B3C0D4B223E0DB56002D984F /* CustomDialogs.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B3C0D4B123E0DB56002D984F /* CustomDialogs.storyboard */; };
-        B3C0D4B423E0DBF6002D984F /* SimpleTextInputDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C0D4B323E0DBF6002D984F /* SimpleTextInputDialog.swift */; };
-        B3C0D4B623E0FBA5002D984F /* SimpleOkCancelDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C0D4B523E0FBA5002D984F /* SimpleOkCancelDialog.swift */; };
-        B3D21C9F2296E4F000609F23 /* ExchangeRates.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D21C9E2296E4F000609F23 /* ExchangeRates.swift */; };
-        B3D474DF23E55B5D00B6E305 /* WalletSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D474DE23E55B5D00B6E305 /* WalletSettings.swift */; };
-        B3D474E223E56CFD00B6E305 /* CheckableListDialogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D474E123E56CFD00B6E305 /* CheckableListDialogViewController.swift */; };
-        B3D474E423E57DA200B6E305 /* CheckableListOptionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D474E323E57DA200B6E305 /* CheckableListOptionTableViewCell.swift */; };
-        B3E727C423DD4A5F003B06B4 /* WalletInfoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B3E727C323DD4A5F003B06B4 /* WalletInfoTableViewCell.xib */; };
-        B3E727C623DD4ABF003B06B4 /* WalletAccountTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B3E727C523DD4ABF003B06B4 /* WalletAccountTableViewCell.xib */; };
-        B3E727C823DD4AD7003B06B4 /* WalletInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E727C723DD4AD7003B06B4 /* WalletInfoTableViewCell.swift */; };
-        B3E727CA23DD4AE7003B06B4 /* WalletAccountTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E727C923DD4AE7003B06B4 /* WalletAccountTableViewCell.swift */; };
-        B3E727CC23DD506E003B06B4 /* WalletsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E727CB23DD506E003B06B4 /* WalletsViewController.swift */; };
-        B3E727CE23DE0FCC003B06B4 /* Wallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E727CD23DE0FCC003B06B4 /* Wallet.swift */; };
-        C8BBC3AE2450CE1E001A5A9E /* SuffixTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BBC3AD2450CE1E001A5A9E /* SuffixTextField.swift */; };
-        DD02AC6523969440004A73E3 /* MoreMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD02AC6423969440004A73E3 /* MoreMenuItem.swift */; };
-        DD17D9CC23CE243D0017E41D /* RestoreExistingWalletViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD17D9CB23CE243D0017E41D /* RestoreExistingWalletViewController.swift */; };
-        DD2E176E24A95BAC001AF94D /* RestoreExistingWalletUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD2E176D24A95BAC001AF94D /* RestoreExistingWalletUITest.swift */; };
-        DD2E177224A95CA4001AF94D /* SeedBackupUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD2E177124A95CA4001AF94D /* SeedBackupUITest.swift */; };
-        DD36717723B44AB700D1ED67 /* More.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DD36717623B44AB700D1ED67 /* More.storyboard */; };
-        DD398AB825C35B03003BC77D /* PrivacySetupTypeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD398AB725C35B03003BC77D /* PrivacySetupTypeViewController.swift */; };
-        DD398ABB25C35B07003BC77D /* PrivacyManualSetupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD398ABA25C35B07003BC77D /* PrivacyManualSetupViewController.swift */; };
-        DD3DF86622C3F0BD00E168AB /* UILabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD3DF86522C3F0BD00E168AB /* UILabel.swift */; };
-        DD41737B22B1B31E00580935 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = DD41737D22B1B31E00580935 /* Localizable.strings */; };
-        DD493BF8247327E800C0D772 /* MultipleTextInputDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD493BF7247327E800C0D772 /* MultipleTextInputDialog.swift */; };
-        DD493C00247654BC00C0D772 /* WatchOnlyWalletInfoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = DD493BFF247654BC00C0D772 /* WatchOnlyWalletInfoTableViewCell.xib */; };
-        DD493C02247654BC00C0D772 /* WatchOnlyWalletInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD493C01247654BC00C0D772 /* WatchOnlyWalletInfoTableViewCell.swift */; };
-        DD493C04247654BC00C0D772 /* WatchOnlyWalletTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD493C03247654BC00C0D772 /* WatchOnlyWalletTableViewCell.swift */; };
-        DD493C06247654BC00C0D772 /* WatchOnlyWalletTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = DD493C05247654BC00C0D772 /* WatchOnlyWalletTableViewCell.xib */; };
-        DD4948EC22C0E400006A35F8 /* LocalizedStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4948EB22C0E400006A35F8 /* LocalizedStrings.swift */; };
-        DD53FD772459F8B3003CA279 /* beep.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = DD53FD762459F8B3003CA279 /* beep.mp3 */; };
-        DD569298259B9E40004D4BE6 /* PrivacyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD569297259B9E3F004D4BE6 /* PrivacyViewController.swift */; };
-        DD5AB14623BAE47A00863362 /* About.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DD5AB14523BAE47A00863362 /* About.storyboard */; };
-        DD5AB14823BAE47A00863362 /* Debug.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DD5AB14723BAE47A00863362 /* Debug.storyboard */; };
-        DD5AB14A23BAE47A00863362 /* Help.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DD5AB14923BAE47A00863362 /* Help.storyboard */; };
-        DD5AB14C23D36F7E00863362 /* AboutTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD5AB14B23D36F7E00863362 /* AboutTableViewController.swift */; };
-        DD5AB14E23D4C12C00863362 /* DebugTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD5AB14D23D4C12C00863362 /* DebugTableViewController.swift */; };
-        DD5AB15023D612C800863362 /* HelpTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD5AB14F23D612C800863362 /* HelpTableViewController.swift */; };
-        DD67443825CA321C001AD0B5 /* ToolTipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD67443725CA321C001AD0B5 /* ToolTipView.swift */; };
-        DD81CBC323B39DF1009D3833 /* FloatingLabelTextInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD81CBC223B39DF1009D3833 /* FloatingLabelTextInput.swift */; };
-        DD81CBC523B39E6A009D3833 /* PaddedLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD81CBC423B39E6A009D3833 /* PaddedLabel.swift */; };
-        DD81CBC823B3A219009D3833 /* ValidateAddresses.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DD81CBC723B3A219009D3833 /* ValidateAddresses.storyboard */; };
-        DD81CBCA23B3A298009D3833 /* ValidateAddressesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD81CBC923B3A298009D3833 /* ValidateAddressesViewController.swift */; };
-        DD89A04123B0842400C1ECE9 /* SecurityTools.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DD89A04023B0842400C1ECE9 /* SecurityTools.storyboard */; };
-        DD89A04323B08CF800C1ECE9 /* SecurityToolsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD89A04223B08CF800C1ECE9 /* SecurityToolsViewController.swift */; };
-        DD89A04523B08FDD00C1ECE9 /* SecurityToolsItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD89A04423B08FDD00C1ECE9 /* SecurityToolsItem.swift */; };
-        DD89A04723B091FF00C1ECE9 /* SecurityToolsItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD89A04623B091FF00C1ECE9 /* SecurityToolsItemCell.swift */; };
-        DD8F9D3C22BE7A5600FF8594 /* Security.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DD8F9D3B22BE7A5600FF8594 /* Security.storyboard */; };
-        DDA2F7CE24375FEF00A3DC7C /* StatisticsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA2F7CD24375FEF00A3DC7C /* StatisticsViewController.swift */; };
-        DDA8154B243E56750011333F /* WalletSetup.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DDA8154A243E56740011333F /* WalletSetup.storyboard */; };
-        DDA8734E245F69C00029A13D /* CIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA8734D245F69C00029A13D /* CIImage.swift */; };
-        DDAE91002435086B00FEC016 /* KeychainWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE90FF2435086B00FEC016 /* KeychainWrapper.swift */; };
-        DDAE91022435092200FEC016 /* KeychainItemAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE91012435092200FEC016 /* KeychainItemAccessibility.swift */; };
-        DDAE91042435092200FEC016 /* ErrorMessageForLA.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE91032435092200FEC016 /* ErrorMessageForLA.swift */; };
-        DDB660F52486BABB0060B0C5 /* Decred_WalletUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB660F42486BABB0060B0C5 /* Decred_WalletUITests.swift */; };
-        DDCF259A22B8A347005FCBB9 /* Overview.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DDCF259922B8A346005FCBB9 /* Overview.storyboard */; };
-        DDCF259C22B8A362005FCBB9 /* Send.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DDCF259B22B8A361005FCBB9 /* Send.storyboard */; };
-        DDCF25A122B8A3D4005FCBB9 /* Settings.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DDCF25A022B8A3D4005FCBB9 /* Settings.storyboard */; };
-        DDCF25A922B8A488005FCBB9 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DDCF25A822B8A487005FCBB9 /* Main.storyboard */; };
-        DDD65AD722A935460027CDA8 /* LicenseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDD65AD622A935460027CDA8 /* LicenseViewController.swift */; };
-        DDD7D20925C1BCCB0013BF0A /* Privacy.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DDD7D20825C1BCCB0013BF0A /* Privacy.storyboard */; };
-        DDDF95CC23C11F760057AA7F /* VerifyMessage.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DDDF95CB23C11F760057AA7F /* VerifyMessage.storyboard */; };
-        DDDF95CE23C11F760057AA7F /* VerifyMessageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDF95CD23C11F760057AA7F /* VerifyMessageViewController.swift */; };
-        DDDF95D523C20AA70057AA7F /* SignMessage.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DDDF95D423C20AA70057AA7F /* SignMessage.storyboard */; };
-        DDDF95D723C20AA70057AA7F /* SignMessageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDF95D623C20AA70057AA7F /* SignMessageViewController.swift */; };
-        DDE2374623BA386C00C2A94F /* MoreMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE2374523BA386C00C2A94F /* MoreMenuViewController.swift */; };
-        DDE2374823BA386C00C2A94F /* MoreMenuItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE2374723BA386C00C2A94F /* MoreMenuItemCell.swift */; };
-        DDEEEE1825AB1B8E00794B67 /* PrivacySetupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDEEEE1725AB1B8E00794B67 /* PrivacySetupViewController.swift */; };
+		100B122923E9EEAC005636A7 /* TransactionTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 100B122523E9EEAC005636A7 /* TransactionTableViewCell.xib */; };
+		100B122A23E9EEAC005636A7 /* TransactionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100B122623E9EEAC005636A7 /* TransactionTableViewCell.swift */; };
+		100B122B23E9EEAC005636A7 /* Transactions.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 100B122723E9EEAC005636A7 /* Transactions.storyboard */; };
+		100B122C23E9EEAC005636A7 /* TransactionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100B122823E9EEAC005636A7 /* TransactionsViewController.swift */; };
+		100B122E23E9EECB005636A7 /* RestoreExistingWalletSuccessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100B122D23E9EECB005636A7 /* RestoreExistingWalletSuccessViewController.swift */; };
+		102AFAC423AA2B4D007E2EBD /* ProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102AFAC323AA2B4D007E2EBD /* ProgressView.swift */; };
+		102D724B23ED5271002DCAF2 /* TransactionDetailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102D724723ED5271002DCAF2 /* TransactionDetailCell.swift */; };
+		10341E0723CBBB700055DFDE /* SeedBackupSuccessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10341E0023CBBB700055DFDE /* SeedBackupSuccessViewController.swift */; };
+		10341E0823CBBB700055DFDE /* SeedWordsDisplayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10341E0123CBBB700055DFDE /* SeedWordsDisplayViewController.swift */; };
+		10341E0923CBBB700055DFDE /* SeedBackupVerifyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10341E0223CBBB700055DFDE /* SeedBackupVerifyViewController.swift */; };
+		10341E0A23CBBB700055DFDE /* SeedBackupVerifyTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10341E0323CBBB700055DFDE /* SeedBackupVerifyTableViewCell.swift */; };
+		10341E0B23CBBB700055DFDE /* SeedWordsDisplayTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10341E0423CBBB700055DFDE /* SeedWordsDisplayTableViewCell.swift */; };
+		10341E0C23CBBB700055DFDE /* SeedBackup.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 10341E0523CBBB700055DFDE /* SeedBackup.storyboard */; };
+		10341E0D23CBBB700055DFDE /* SeedBackupReminderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10341E0623CBBB700055DFDE /* SeedBackupReminderViewController.swift */; };
+		10341E0F23CBBB7E0055DFDE /* Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10341E0E23CBBB7E0055DFDE /* Label.swift */; };
+		1034D5CF24113BF10009576C /* SimpleAlertDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1034D5CE24113BF10009576C /* SimpleAlertDialog.swift */; };
+		103BE67E240D1F9E007910DA /* WalletSelectorCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103BE67D240D1F9E007910DA /* WalletSelectorCollectionViewCell.swift */; };
+		105836B823EACD390030FDF2 /* ReceiveViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105836B623EACD390030FDF2 /* ReceiveViewController.swift */; };
+		105836B923EACD390030FDF2 /* Receive.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 105836B723EACD390030FDF2 /* Receive.storyboard */; };
+		108A2E7423DE311900B13A22 /* SelfSizedTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 108A2E7323DE311900B13A22 /* SelfSizedTableView.swift */; };
+		10945CDA23F3DB0C00BBE242 /* TransactionOverviewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10945CD923F3DB0C00BBE242 /* TransactionOverviewCell.swift */; };
+		10B7818223F066DA00AD2709 /* TransactionInputDetailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10B7818023F066DA00AD2709 /* TransactionInputDetailCell.swift */; };
+		10B7818523F0693C00AD2709 /* TransactionOutputDetailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10B7818423F0693C00AD2709 /* TransactionOutputDetailCell.swift */; };
+		10BA77992390059F00B67446 /* TabMenuItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10BA77982390059F00B67446 /* TabMenuItemView.swift */; };
+		10C6610E23EC587B00754DED /* AccountSelectorDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C6610B23EC587B00754DED /* AccountSelectorDialog.swift */; };
+		10C6610F23EC587B00754DED /* AccountSelectorTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 10C6610C23EC587B00754DED /* AccountSelectorTableViewCell.xib */; };
+		10C6611023EC587B00754DED /* AccountSelectorTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C6610D23EC587B00754DED /* AccountSelectorTableViewCell.swift */; };
+		10D9FB9323C3956300CBF216 /* FloatingPlaceholderTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D9FB8E23C3956200CBF216 /* FloatingPlaceholderTextField.swift */; };
+		10D9FB9623C3956300CBF216 /* FloatingPlaceholderLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D9FB9123C3956300CBF216 /* FloatingPlaceholderLabel.swift */; };
+		10FABE4B23C72D6800BC201B /* FloatingPlaceholderInputProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FABE4A23C72D6700BC201B /* FloatingPlaceholderInputProtocol.swift */; };
+		10FABE4F23C7303E00BC201B /* FloatingPlaceholderTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FABE4E23C7303E00BC201B /* FloatingPlaceholderTextView.swift */; };
+		10FABE5123C7307100BC201B /* FloatingPlaceholderBorderLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FABE5023C7307100BC201B /* FloatingPlaceholderBorderLayer.swift */; };
+		250D77BD23F2BF0F00CDC256 /* DecredAddressURI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 250D77BC23F2BF0F00CDC256 /* DecredAddressURI.swift */; };
+		2557E1892355C6FA00B6A1B7 /* NavigationMenuTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2557E1882355C6FA00B6A1B7 /* NavigationMenuTabBarController.swift */; };
+		2557E18B2355C9F000B6A1B7 /* CustomTabMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2557E18A2355C9F000B6A1B7 /* CustomTabMenuView.swift */; };
+		25751F532372C9460019F657 /* Dcrlibwallet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25751F522372C9460019F657 /* Dcrlibwallet.framework */; };
+		25A4331C2373D0330018FFCF /* SyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25A4331B2373D0330018FFCF /* SyncManager.swift */; };
+		25E63F4E23312B2C009CD53E /* NavMenuFloatingButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E63F4D23312B2B009CD53E /* NavMenuFloatingButtons.swift */; };
+		6004FFB825CC5D0100D5A25C /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6004FFB725CC5D0100D5A25C /* LoadingView.swift */; };
+		6007D38B24F406AA000EC5CB /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6007D38A24F406AA000EC5CB /* Response.swift */; };
+		6007D38D24F42089000EC5CB /* PoliteiaNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6007D38C24F42089000EC5CB /* PoliteiaNotification.swift */; };
+		60778AE026274DA9006B1FC2 /* WalletMixerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60778ADF26274DA9006B1FC2 /* WalletMixerCell.swift */; };
+		60C7E54124ED8738009E4569 /* PlainHorizontalProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C7E54024ED8738009E4569 /* PlainHorizontalProgressBar.swift */; };
+		60C7E54624ED88B8009E4569 /* Politeia.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 60C7E54324ED88B8009E4569 /* Politeia.storyboard */; };
+		60C7E54724ED88B8009E4569 /* PoliteiaTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C7E54424ED88B8009E4569 /* PoliteiaTableViewCell.swift */; };
+		60C7E54824ED88B8009E4569 /* PoliteiaController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C7E54524ED88B8009E4569 /* PoliteiaController.swift */; };
+		60C7E54B24ED88F0009E4569 /* PoliteiaStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C7E54924ED88F0009E4569 /* PoliteiaStatus.swift */; };
+		60C7E54C24ED88F0009E4569 /* Politeia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C7E54A24ED88F0009E4569 /* Politeia.swift */; };
+		60DFF5D124F75D4500624161 /* PoliteiaDetailController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DFF5D024F75D4500624161 /* PoliteiaDetailController.swift */; };
+		60E853A025B324C800E4CFDD /* ConnectedPeerViewcontroller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E8539F25B324C800E4CFDD /* ConnectedPeerViewcontroller.swift */; };
+		60E853A425B4805200E4CFDD /* PeerInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E853A325B4805200E4CFDD /* PeerInfo.swift */; };
+		60E853A825B48F9800E4CFDD /* ConnectedPeerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E853A725B48F9800E4CFDD /* ConnectedPeerTableViewCell.swift */; };
+		AD24C23D2343E445009583C9 /* NotificationsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD24C23C2343E445009583C9 /* NotificationsManager.swift */; };
+		B164982429AEDD7AF8C8782C /* Pods_Decred_Wallet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9714AB438E597D403032748 /* Pods_Decred_Wallet.framework */; };
+		B304B39423F202A400B81798 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B304B39323F202A400B81798 /* Settings.swift */; };
+		B32EB42E23EEA24000E43D4F /* AccountDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32EB42D23EEA24000E43D4F /* AccountDetailsViewController.swift */; };
+		B3456D2523D91CF600B04860 /* RoundedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3456D2423D91CF600B04860 /* RoundedView.swift */; };
+		B34A2F8F23E8E90500B8BC01 /* WalletSyncDetailsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34A2F8E23E8E90500B8BC01 /* WalletSyncDetailsTableViewCell.swift */; };
+		B34A2F9123E8ED1500B8BC01 /* MultiWalletSyncDetailsLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34A2F9023E8ED1500B8BC01 /* MultiWalletSyncDetailsLoader.swift */; };
+		B35C55D8232FED610006A765 /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35C55D7232FED610006A765 /* Transaction.swift */; };
+		B3635B82229FE5870052EB4D /* QRImageScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3635B81229FE5870052EB4D /* QRImageScanner.swift */; };
+		B36EFD362298617C002753B2 /* UIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36EFD352298617C002753B2 /* UIButton.swift */; };
+		B379BA6523E2A2F1002CA92E /* SingleToMultiWalletMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B379BA6423E2A2F1002CA92E /* SingleToMultiWalletMigration.swift */; };
+		B37AD0A32408870B00C83D80 /* WalletAccountView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B37AD0A22408870B00C83D80 /* WalletAccountView.xib */; };
+		B37AD0A524088A6700C83D80 /* WalletAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37AD0A424088A6700C83D80 /* WalletAccountView.swift */; };
+		B3967B3D22A75BD400E14432 /* UITableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3967B3C22A75BD400E14432 /* UITableView.swift */; };
+		B39BDC4D228F798300F3FB55 /* BuildConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39BDC4C228F798300F3FB55 /* BuildConfig.swift */; };
+		B3A3EF8622936BFE00008A4E /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A3EF8522936BFE00008A4E /* Reachability.swift */; };
+		B3A3EF88229375D100008A4E /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A3EF87229375D100008A4E /* Date.swift */; };
+		B3A3EF922295956300008A4E /* SendViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A3EF912295956300008A4E /* SendViewController.swift */; };
+		B3A8E80A23E593720094957B /* CheckableListOptionTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B3A8E80923E593720094957B /* CheckableListOptionTableViewCell.xib */; };
+		B3B46993228F0C2E00A68EDD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46992228F0C2E00A68EDD /* AppDelegate.swift */; };
+		B3B4699A228F0C2E00A68EDD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B3B46999228F0C2E00A68EDD /* Assets.xcassets */; };
+		B3B4699D228F0C2E00A68EDD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B3B4699B228F0C2E00A68EDD /* LaunchScreen.storyboard */; };
+		B3B469FA228F0F2700A68EDD /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469A8228F0F2600A68EDD /* UIColor.swift */; };
+		B3B469FB228F0F2700A68EDD /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469A9228F0F2600A68EDD /* Extensions.swift */; };
+		B3B469FC228F0F2700A68EDD /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469AA228F0F2600A68EDD /* String.swift */; };
+		B3B469FD228F0F2700A68EDD /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469AB228F0F2600A68EDD /* UIViewController.swift */; };
+		B3B469FE228F0F2700A68EDD /* Button.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469AD228F0F2600A68EDD /* Button.swift */; };
+		B3B46A00228F0F2700A68EDD /* inconsolata_regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469B1228F0F2600A68EDD /* inconsolata_regular.ttf */; };
+		B3B46A01228F0F2700A68EDD /* SourceSansPro-BlackItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469B3228F0F2600A68EDD /* SourceSansPro-BlackItalic.ttf */; };
+		B3B46A02228F0F2700A68EDD /* SourceSansPro-SemiBoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469B4228F0F2600A68EDD /* SourceSansPro-SemiBoldItalic.ttf */; };
+		B3B46A03228F0F2700A68EDD /* SourceSansPro-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469B5228F0F2600A68EDD /* SourceSansPro-Regular.ttf */; };
+		B3B46A04228F0F2700A68EDD /* SourceSansPro-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469B6228F0F2600A68EDD /* SourceSansPro-Bold.ttf */; };
+		B3B46A05228F0F2700A68EDD /* SourceSansPro-LightItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469B7228F0F2600A68EDD /* SourceSansPro-LightItalic.ttf */; };
+		B3B46A06228F0F2700A68EDD /* SourceSansPro-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469B8228F0F2600A68EDD /* SourceSansPro-Light.ttf */; };
+		B3B46A07228F0F2700A68EDD /* SourceSansPro-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469B9228F0F2600A68EDD /* SourceSansPro-Black.ttf */; };
+		B3B46A08228F0F2700A68EDD /* SourceSansPro-ExtraLight.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469BA228F0F2600A68EDD /* SourceSansPro-ExtraLight.ttf */; };
+		B3B46A09228F0F2700A68EDD /* SourceSansPro-BoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469BB228F0F2600A68EDD /* SourceSansPro-BoldItalic.ttf */; };
+		B3B46A0A228F0F2700A68EDD /* SourceSansPro-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469BC228F0F2600A68EDD /* SourceSansPro-SemiBold.ttf */; };
+		B3B46A0B228F0F2700A68EDD /* SourceSansPro-ExtraLightItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469BD228F0F2600A68EDD /* SourceSansPro-ExtraLightItalic.ttf */; };
+		B3B46A0C228F0F2700A68EDD /* SourceSansPro-Italic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B469BE228F0F2600A68EDD /* SourceSansPro-Italic.ttf */; };
+		B3B46A0D228F0F2700A68EDD /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469C0228F0F2600A68EDD /* Constants.swift */; };
+		B3B46A0E228F0F2700A68EDD /* wordlist.txt in Resources */ = {isa = PBXBuildFile; fileRef = B3B469C1228F0F2600A68EDD /* wordlist.txt */; };
+		B3B46A10228F0F2700A68EDD /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469C7228F0F2600A68EDD /* UIView.swift */; };
+		B3B46A11228F0F2700A68EDD /* UITableViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469C8228F0F2600A68EDD /* UITableViewExtension.swift */; };
+		B3B46A12228F0F2700A68EDD /* TextFieldDoneButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469C9228F0F2600A68EDD /* TextFieldDoneButton.swift */; };
+		B3B46A15228F0F2700A68EDD /* UIImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469CD228F0F2600A68EDD /* UIImageView.swift */; };
+		B3B46A17228F0F2700A68EDD /* ContouredButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469CF228F0F2600A68EDD /* ContouredButton.swift */; };
+		B3B46A18228F0F2700A68EDD /* DropDownSearchField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469D0228F0F2600A68EDD /* DropDownSearchField.swift */; };
+		B3B46A19228F0F2700A68EDD /* StartScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469D3228F0F2600A68EDD /* StartScreenViewController.swift */; };
+		B3B46A1B228F0F2700A68EDD /* SecurityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469D6228F0F2600A68EDD /* SecurityViewController.swift */; };
+		B3B46A1D228F0F2700A68EDD /* RequestPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469D8228F0F2600A68EDD /* RequestPasswordViewController.swift */; };
+		B3B46A1F228F0F2700A68EDD /* RequestPinViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469DA228F0F2600A68EDD /* RequestPinViewController.swift */; };
+		B3B46A20228F0F2700A68EDD /* PinPasswordStrength.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469DB228F0F2600A68EDD /* PinPasswordStrength.swift */; };
+		B3B46A21228F0F2700A68EDD /* SecurityCodeRequestBaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469DC228F0F2600A68EDD /* SecurityCodeRequestBaseViewController.swift */; };
+		B3B46A2E228F0F2700A68EDD /* MenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469EC228F0F2600A68EDD /* MenuItem.swift */; };
+		B3B46A32228F0F2700A68EDD /* OverviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469F1228F0F2600A68EDD /* OverviewViewController.swift */; };
+		B3B46A34228F0F2700A68EDD /* TransactionNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469F4228F0F2600A68EDD /* TransactionNotification.swift */; };
+		B3B46A36228F0F2700A68EDD /* WalletLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469F6228F0F2600A68EDD /* WalletLoader.swift */; };
+		B3B46A37228F0F2700A68EDD /* SpendingPinOrPassword.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469F7228F0F2600A68EDD /* SpendingPinOrPassword.swift */; };
+		B3B46A38228F0F2700A68EDD /* Dcrlibwallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469F8228F0F2600A68EDD /* Dcrlibwallet.swift */; };
+		B3B46A39228F0F2700A68EDD /* StartupPinOrPassword.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B469F9228F0F2600A68EDD /* StartupPinOrPassword.swift */; };
+		B3B46A3F228F0F6700A68EDD /* bg-button@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = B3B46A3B228F0F6700A68EDD /* bg-button@3x.png */; };
+		B3B46A40228F0F6700A68EDD /* bg-button.png in Resources */ = {isa = PBXBuildFile; fileRef = B3B46A3C228F0F6700A68EDD /* bg-button.png */; };
+		B3B46A41228F0F6700A68EDD /* dcr-logo.png in Resources */ = {isa = PBXBuildFile; fileRef = B3B46A3D228F0F6700A68EDD /* dcr-logo.png */; };
+		B3B46A42228F0F6700A68EDD /* progress bar-1s-200px.gif in Resources */ = {isa = PBXBuildFile; fileRef = B3B46A3E228F0F6700A68EDD /* progress bar-1s-200px.gif */; };
+		B3B46A86228F0F7D00A68EDD /* DropMenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A49228F0F7B00A68EDD /* DropMenuButton.swift */; };
+		B3B46A87228F0F7D00A68EDD /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A4A228F0F7B00A68EDD /* Data.swift */; };
+		B3B46A88228F0F7D00A68EDD /* UIIMage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A4B228F0F7B00A68EDD /* UIIMage.swift */; };
+		B3B46A89228F0F7D00A68EDD /* keyPadButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A4C228F0F7B00A68EDD /* keyPadButton.swift */; };
+		B3B46A8A228F0F7D00A68EDD /* customUImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A4D228F0F7B00A68EDD /* customUImage.swift */; };
+		B3B46A8C228F0F7D00A68EDD /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A4F228F0F7B00A68EDD /* Utils.swift */; };
+		B3B46A8F228F0F7D00A68EDD /* ConfirmToSendFundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A54228F0F7B00A68EDD /* ConfirmToSendFundViewController.swift */; };
+		B3B46A97228F0F7D00A68EDD /* TransactionDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A5E228F0F7B00A68EDD /* TransactionDetailsViewController.swift */; };
+		B3B46A98228F0F7D00A68EDD /* TransactionDetails.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B3B46A5F228F0F7B00A68EDD /* TransactionDetails.storyboard */; };
+		B3B46A9A228F0F7D00A68EDD /* SettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A61228F0F7B00A68EDD /* SettingsController.swift */; };
+		B3B46A9B228F0F7D00A68EDD /* PeerSetTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A62228F0F7B00A68EDD /* PeerSetTableViewController.swift */; };
+		B3B46A9F228F0F7D00A68EDD /* WalletLogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A66228F0F7B00A68EDD /* WalletLogViewController.swift */; };
+		B3B46AA7228F0F7D00A68EDD /* CurrencyConversionOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A6F228F0F7B00A68EDD /* CurrencyConversionOptionsViewController.swift */; };
+		B3B46AAC228F0F7D00A68EDD /* RecoveryWalletSeedWordCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A75228F0F7C00A68EDD /* RecoveryWalletSeedWordCell.swift */; };
+		B3B46AB1228F0F7D00A68EDD /* SeedCheckActiveCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A7A228F0F7C00A68EDD /* SeedCheckActiveCellView.swift */; };
+		B3B46AB3228F0F7D00A68EDD /* ConfirmSeedViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A7C228F0F7C00A68EDD /* ConfirmSeedViewCell.swift */; };
+		B3B46AB6228F0F7D00A68EDD /* Storyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B46A7F228F0F7C00A68EDD /* Storyboard.swift */; };
+		B3B9432923E4D0B30088EC3E /* WalletSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B9432823E4D0B30088EC3E /* WalletSettingsViewController.swift */; };
+		B3C03B2323DD41EE00156D9F /* Wallets.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B3C03B2223DD41EE00156D9F /* Wallets.storyboard */; };
+		B3C0D4AF23DF9C45002D984F /* Security.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C0D4AE23DF9C45002D984F /* Security.swift */; };
+		B3C0D4B223E0DB56002D984F /* CustomDialogs.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B3C0D4B123E0DB56002D984F /* CustomDialogs.storyboard */; };
+		B3C0D4B423E0DBF6002D984F /* SimpleTextInputDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C0D4B323E0DBF6002D984F /* SimpleTextInputDialog.swift */; };
+		B3C0D4B623E0FBA5002D984F /* SimpleOkCancelDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C0D4B523E0FBA5002D984F /* SimpleOkCancelDialog.swift */; };
+		B3D21C9F2296E4F000609F23 /* ExchangeRates.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D21C9E2296E4F000609F23 /* ExchangeRates.swift */; };
+		B3D474DF23E55B5D00B6E305 /* WalletSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D474DE23E55B5D00B6E305 /* WalletSettings.swift */; };
+		B3D474E223E56CFD00B6E305 /* CheckableListDialogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D474E123E56CFD00B6E305 /* CheckableListDialogViewController.swift */; };
+		B3D474E423E57DA200B6E305 /* CheckableListOptionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D474E323E57DA200B6E305 /* CheckableListOptionTableViewCell.swift */; };
+		B3E727C423DD4A5F003B06B4 /* WalletInfoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B3E727C323DD4A5F003B06B4 /* WalletInfoTableViewCell.xib */; };
+		B3E727C623DD4ABF003B06B4 /* WalletAccountTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B3E727C523DD4ABF003B06B4 /* WalletAccountTableViewCell.xib */; };
+		B3E727C823DD4AD7003B06B4 /* WalletInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E727C723DD4AD7003B06B4 /* WalletInfoTableViewCell.swift */; };
+		B3E727CA23DD4AE7003B06B4 /* WalletAccountTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E727C923DD4AE7003B06B4 /* WalletAccountTableViewCell.swift */; };
+		B3E727CC23DD506E003B06B4 /* WalletsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E727CB23DD506E003B06B4 /* WalletsViewController.swift */; };
+		B3E727CE23DE0FCC003B06B4 /* Wallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E727CD23DE0FCC003B06B4 /* Wallet.swift */; };
+		C8BBC3AE2450CE1E001A5A9E /* SuffixTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BBC3AD2450CE1E001A5A9E /* SuffixTextField.swift */; };
+		DD02AC6523969440004A73E3 /* MoreMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD02AC6423969440004A73E3 /* MoreMenuItem.swift */; };
+		DD17D9CC23CE243D0017E41D /* RestoreExistingWalletViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD17D9CB23CE243D0017E41D /* RestoreExistingWalletViewController.swift */; };
+		DD2E176E24A95BAC001AF94D /* RestoreExistingWalletUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD2E176D24A95BAC001AF94D /* RestoreExistingWalletUITest.swift */; };
+		DD2E177224A95CA4001AF94D /* SeedBackupUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD2E177124A95CA4001AF94D /* SeedBackupUITest.swift */; };
+		DD36717723B44AB700D1ED67 /* More.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DD36717623B44AB700D1ED67 /* More.storyboard */; };
+		DD398AB825C35B03003BC77D /* PrivacySetupTypeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD398AB725C35B03003BC77D /* PrivacySetupTypeViewController.swift */; };
+		DD398ABB25C35B07003BC77D /* PrivacyManualSetupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD398ABA25C35B07003BC77D /* PrivacyManualSetupViewController.swift */; };
+		DD3DF86622C3F0BD00E168AB /* UILabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD3DF86522C3F0BD00E168AB /* UILabel.swift */; };
+		DD41737B22B1B31E00580935 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = DD41737D22B1B31E00580935 /* Localizable.strings */; };
+		DD493BF8247327E800C0D772 /* MultipleTextInputDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD493BF7247327E800C0D772 /* MultipleTextInputDialog.swift */; };
+		DD493C00247654BC00C0D772 /* WatchOnlyWalletInfoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = DD493BFF247654BC00C0D772 /* WatchOnlyWalletInfoTableViewCell.xib */; };
+		DD493C02247654BC00C0D772 /* WatchOnlyWalletInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD493C01247654BC00C0D772 /* WatchOnlyWalletInfoTableViewCell.swift */; };
+		DD493C04247654BC00C0D772 /* WatchOnlyWalletTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD493C03247654BC00C0D772 /* WatchOnlyWalletTableViewCell.swift */; };
+		DD493C06247654BC00C0D772 /* WatchOnlyWalletTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = DD493C05247654BC00C0D772 /* WatchOnlyWalletTableViewCell.xib */; };
+		DD4948EC22C0E400006A35F8 /* LocalizedStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4948EB22C0E400006A35F8 /* LocalizedStrings.swift */; };
+		DD53FD772459F8B3003CA279 /* beep.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = DD53FD762459F8B3003CA279 /* beep.mp3 */; };
+		DD569298259B9E40004D4BE6 /* PrivacyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD569297259B9E3F004D4BE6 /* PrivacyViewController.swift */; };
+		DD5AB14623BAE47A00863362 /* About.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DD5AB14523BAE47A00863362 /* About.storyboard */; };
+		DD5AB14823BAE47A00863362 /* Debug.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DD5AB14723BAE47A00863362 /* Debug.storyboard */; };
+		DD5AB14A23BAE47A00863362 /* Help.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DD5AB14923BAE47A00863362 /* Help.storyboard */; };
+		DD5AB14C23D36F7E00863362 /* AboutTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD5AB14B23D36F7E00863362 /* AboutTableViewController.swift */; };
+		DD5AB14E23D4C12C00863362 /* DebugTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD5AB14D23D4C12C00863362 /* DebugTableViewController.swift */; };
+		DD5AB15023D612C800863362 /* HelpTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD5AB14F23D612C800863362 /* HelpTableViewController.swift */; };
+		DD67443825CA321C001AD0B5 /* ToolTipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD67443725CA321C001AD0B5 /* ToolTipView.swift */; };
+		DD81CBC323B39DF1009D3833 /* FloatingLabelTextInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD81CBC223B39DF1009D3833 /* FloatingLabelTextInput.swift */; };
+		DD81CBC523B39E6A009D3833 /* PaddedLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD81CBC423B39E6A009D3833 /* PaddedLabel.swift */; };
+		DD81CBC823B3A219009D3833 /* ValidateAddresses.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DD81CBC723B3A219009D3833 /* ValidateAddresses.storyboard */; };
+		DD81CBCA23B3A298009D3833 /* ValidateAddressesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD81CBC923B3A298009D3833 /* ValidateAddressesViewController.swift */; };
+		DD89A04123B0842400C1ECE9 /* SecurityTools.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DD89A04023B0842400C1ECE9 /* SecurityTools.storyboard */; };
+		DD89A04323B08CF800C1ECE9 /* SecurityToolsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD89A04223B08CF800C1ECE9 /* SecurityToolsViewController.swift */; };
+		DD89A04523B08FDD00C1ECE9 /* SecurityToolsItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD89A04423B08FDD00C1ECE9 /* SecurityToolsItem.swift */; };
+		DD89A04723B091FF00C1ECE9 /* SecurityToolsItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD89A04623B091FF00C1ECE9 /* SecurityToolsItemCell.swift */; };
+		DD8F9D3C22BE7A5600FF8594 /* Security.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DD8F9D3B22BE7A5600FF8594 /* Security.storyboard */; };
+		DDA2F7CE24375FEF00A3DC7C /* StatisticsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA2F7CD24375FEF00A3DC7C /* StatisticsViewController.swift */; };
+		DDA8154B243E56750011333F /* WalletSetup.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DDA8154A243E56740011333F /* WalletSetup.storyboard */; };
+		DDA8734E245F69C00029A13D /* CIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA8734D245F69C00029A13D /* CIImage.swift */; };
+		DDAE91002435086B00FEC016 /* KeychainWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE90FF2435086B00FEC016 /* KeychainWrapper.swift */; };
+		DDAE91022435092200FEC016 /* KeychainItemAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE91012435092200FEC016 /* KeychainItemAccessibility.swift */; };
+		DDAE91042435092200FEC016 /* ErrorMessageForLA.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE91032435092200FEC016 /* ErrorMessageForLA.swift */; };
+		DDB660F52486BABB0060B0C5 /* Decred_WalletUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB660F42486BABB0060B0C5 /* Decred_WalletUITests.swift */; };
+		DDCF259A22B8A347005FCBB9 /* Overview.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DDCF259922B8A346005FCBB9 /* Overview.storyboard */; };
+		DDCF259C22B8A362005FCBB9 /* Send.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DDCF259B22B8A361005FCBB9 /* Send.storyboard */; };
+		DDCF25A122B8A3D4005FCBB9 /* Settings.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DDCF25A022B8A3D4005FCBB9 /* Settings.storyboard */; };
+		DDCF25A922B8A488005FCBB9 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DDCF25A822B8A487005FCBB9 /* Main.storyboard */; };
+		DDD65AD722A935460027CDA8 /* LicenseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDD65AD622A935460027CDA8 /* LicenseViewController.swift */; };
+		DDD7D20925C1BCCB0013BF0A /* Privacy.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DDD7D20825C1BCCB0013BF0A /* Privacy.storyboard */; };
+		DDDF95CC23C11F760057AA7F /* VerifyMessage.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DDDF95CB23C11F760057AA7F /* VerifyMessage.storyboard */; };
+		DDDF95CE23C11F760057AA7F /* VerifyMessageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDF95CD23C11F760057AA7F /* VerifyMessageViewController.swift */; };
+		DDDF95D523C20AA70057AA7F /* SignMessage.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DDDF95D423C20AA70057AA7F /* SignMessage.storyboard */; };
+		DDDF95D723C20AA70057AA7F /* SignMessageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDF95D623C20AA70057AA7F /* SignMessageViewController.swift */; };
+		DDE2374623BA386C00C2A94F /* MoreMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE2374523BA386C00C2A94F /* MoreMenuViewController.swift */; };
+		DDE2374823BA386C00C2A94F /* MoreMenuItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE2374723BA386C00C2A94F /* MoreMenuItemCell.swift */; };
+		DDEEEE1825AB1B8E00794B67 /* PrivacySetupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDEEEE1725AB1B8E00794B67 /* PrivacySetupViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-        DDB660F72486BABB0060B0C5 /* PBXContainerItemProxy */ = {
-            isa = PBXContainerItemProxy;
-            containerPortal = B3B46987228F0C2D00A68EDD /* Project object */;
-            proxyType = 1;
-            remoteGlobalIDString = B3B4698E228F0C2D00A68EDD;
-            remoteInfo = "Decred Wallet";
-        };
+		DDB660F72486BABB0060B0C5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B3B46987228F0C2D00A68EDD /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B3B4698E228F0C2D00A68EDD;
+			remoteInfo = "Decred Wallet";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-        100B122523E9EEAC005636A7 /* TransactionTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TransactionTableViewCell.xib; sourceTree = "<group>"; };
-        100B122623E9EEAC005636A7 /* TransactionTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionTableViewCell.swift; sourceTree = "<group>"; };
-        100B122723E9EEAC005636A7 /* Transactions.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Transactions.storyboard; sourceTree = "<group>"; };
-        100B122823E9EEAC005636A7 /* TransactionsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionsViewController.swift; sourceTree = "<group>"; };
-        100B122D23E9EECB005636A7 /* RestoreExistingWalletSuccessViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RestoreExistingWalletSuccessViewController.swift; sourceTree = "<group>"; };
-        102AFAC323AA2B4D007E2EBD /* ProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressView.swift; sourceTree = "<group>"; };
-        102D724723ED5271002DCAF2 /* TransactionDetailCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionDetailCell.swift; sourceTree = "<group>"; };
-        10341E0023CBBB700055DFDE /* SeedBackupSuccessViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeedBackupSuccessViewController.swift; sourceTree = "<group>"; };
-        10341E0123CBBB700055DFDE /* SeedWordsDisplayViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeedWordsDisplayViewController.swift; sourceTree = "<group>"; };
-        10341E0223CBBB700055DFDE /* SeedBackupVerifyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeedBackupVerifyViewController.swift; sourceTree = "<group>"; };
-        10341E0323CBBB700055DFDE /* SeedBackupVerifyTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeedBackupVerifyTableViewCell.swift; sourceTree = "<group>"; };
-        10341E0423CBBB700055DFDE /* SeedWordsDisplayTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeedWordsDisplayTableViewCell.swift; sourceTree = "<group>"; };
-        10341E0523CBBB700055DFDE /* SeedBackup.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = SeedBackup.storyboard; sourceTree = "<group>"; };
-        10341E0623CBBB700055DFDE /* SeedBackupReminderViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeedBackupReminderViewController.swift; sourceTree = "<group>"; };
-        10341E0E23CBBB7E0055DFDE /* Label.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Label.swift; sourceTree = "<group>"; };
-        1034D5CE24113BF10009576C /* SimpleAlertDialog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimpleAlertDialog.swift; sourceTree = "<group>"; };
-        103BE67D240D1F9E007910DA /* WalletSelectorCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSelectorCollectionViewCell.swift; sourceTree = "<group>"; };
-        105836B623EACD390030FDF2 /* ReceiveViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReceiveViewController.swift; sourceTree = "<group>"; };
-        105836B723EACD390030FDF2 /* Receive.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Receive.storyboard; sourceTree = "<group>"; };
-        108A2E7323DE311900B13A22 /* SelfSizedTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelfSizedTableView.swift; sourceTree = "<group>"; };
-        10945CD923F3DB0C00BBE242 /* TransactionOverviewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionOverviewCell.swift; sourceTree = "<group>"; };
-        10B7818023F066DA00AD2709 /* TransactionInputDetailCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionInputDetailCell.swift; sourceTree = "<group>"; };
-        10B7818423F0693C00AD2709 /* TransactionOutputDetailCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionOutputDetailCell.swift; sourceTree = "<group>"; };
-        10BA77982390059F00B67446 /* TabMenuItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabMenuItemView.swift; sourceTree = "<group>"; };
-        10C6610B23EC587B00754DED /* AccountSelectorDialog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountSelectorDialog.swift; sourceTree = "<group>"; };
-        10C6610C23EC587B00754DED /* AccountSelectorTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AccountSelectorTableViewCell.xib; sourceTree = "<group>"; };
-        10C6610D23EC587B00754DED /* AccountSelectorTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountSelectorTableViewCell.swift; sourceTree = "<group>"; };
-        10D9FB8E23C3956200CBF216 /* FloatingPlaceholderTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatingPlaceholderTextField.swift; sourceTree = "<group>"; };
-        10D9FB9123C3956300CBF216 /* FloatingPlaceholderLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatingPlaceholderLabel.swift; sourceTree = "<group>"; };
-        10FABE4A23C72D6700BC201B /* FloatingPlaceholderInputProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatingPlaceholderInputProtocol.swift; sourceTree = "<group>"; };
-        10FABE4E23C7303E00BC201B /* FloatingPlaceholderTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatingPlaceholderTextView.swift; sourceTree = "<group>"; };
-        10FABE5023C7307100BC201B /* FloatingPlaceholderBorderLayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatingPlaceholderBorderLayer.swift; sourceTree = "<group>"; };
-        23F5A25CDDC0ADF47F98ED95 /* Pods-Decred Wallet.mainnet release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Decred Wallet.mainnet release.xcconfig"; path = "Target Support Files/Pods-Decred Wallet/Pods-Decred Wallet.mainnet release.xcconfig"; sourceTree = "<group>"; };
-        250D77BC23F2BF0F00CDC256 /* DecredAddressURI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecredAddressURI.swift; sourceTree = "<group>"; };
-        2557E1882355C6FA00B6A1B7 /* NavigationMenuTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationMenuTabBarController.swift; sourceTree = "<group>"; };
-        2557E18A2355C9F000B6A1B7 /* CustomTabMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTabMenuView.swift; sourceTree = "<group>"; };
-        25751F522372C9460019F657 /* Dcrlibwallet.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Dcrlibwallet.framework; path = libs/Dcrlibwallet.framework; sourceTree = "<group>"; };
-        25A4331B2373D0330018FFCF /* SyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncManager.swift; sourceTree = "<group>"; };
-        25E63F4D23312B2B009CD53E /* NavMenuFloatingButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavMenuFloatingButtons.swift; sourceTree = "<group>"; };
-        60778ADF26274DA9006B1FC2 /* WalletMixerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletMixerCell.swift; sourceTree = "<group>"; };
-        6004FFB725CC5D0100D5A25C /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
-        6007D38A24F406AA000EC5CB /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
-        6007D38C24F42089000EC5CB /* PoliteiaNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoliteiaNotification.swift; sourceTree = "<group>"; };
-        6091E9A8255000CE0028E67F /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
-        60C7E54024ED8738009E4569 /* PlainHorizontalProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainHorizontalProgressBar.swift; sourceTree = "<group>"; };
-        60C7E54324ED88B8009E4569 /* Politeia.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Politeia.storyboard; sourceTree = "<group>"; };
-        60C7E54424ED88B8009E4569 /* PoliteiaTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PoliteiaTableViewCell.swift; sourceTree = "<group>"; };
-        60C7E54524ED88B8009E4569 /* PoliteiaController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PoliteiaController.swift; sourceTree = "<group>"; };
-        60C7E54924ED88F0009E4569 /* PoliteiaStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PoliteiaStatus.swift; sourceTree = "<group>"; };
-        60C7E54A24ED88F0009E4569 /* Politeia.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Politeia.swift; sourceTree = "<group>"; };
-        60DFF5D024F75D4500624161 /* PoliteiaDetailController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoliteiaDetailController.swift; sourceTree = "<group>"; };
-        60E8539F25B324C800E4CFDD /* ConnectedPeerViewcontroller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedPeerViewcontroller.swift; sourceTree = "<group>"; };
-        60E853A325B4805200E4CFDD /* PeerInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerInfo.swift; sourceTree = "<group>"; };
-        60E853A725B48F9800E4CFDD /* ConnectedPeerTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedPeerTableViewCell.swift; sourceTree = "<group>"; };
-        6A0625AB1C6ACD2EC77F544F /* Pods-Decred Wallet.mainnet debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Decred Wallet.mainnet debug.xcconfig"; path = "Target Support Files/Pods-Decred Wallet/Pods-Decred Wallet.mainnet debug.xcconfig"; sourceTree = "<group>"; };
-        A9714AB438E597D403032748 /* Pods_Decred_Wallet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Decred_Wallet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-        AD24C23C2343E445009583C9 /* NotificationsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsManager.swift; sourceTree = "<group>"; };
-        B107091A1D996651AB5D8891 /* Pods-Decred Wallet.testnet debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Decred Wallet.testnet debug.xcconfig"; path = "Target Support Files/Pods-Decred Wallet/Pods-Decred Wallet.testnet debug.xcconfig"; sourceTree = "<group>"; };
-        B304B39323F202A400B81798 /* Settings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
-        B32EB42D23EEA24000E43D4F /* AccountDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDetailsViewController.swift; sourceTree = "<group>"; };
-        B3456D2423D91CF600B04860 /* RoundedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedView.swift; sourceTree = "<group>"; };
-        B34A2F8E23E8E90500B8BC01 /* WalletSyncDetailsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSyncDetailsTableViewCell.swift; sourceTree = "<group>"; };
-        B34A2F9023E8ED1500B8BC01 /* MultiWalletSyncDetailsLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiWalletSyncDetailsLoader.swift; sourceTree = "<group>"; };
-        B35C55D7232FED610006A765 /* Transaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transaction.swift; sourceTree = "<group>"; };
-        B3635B81229FE5870052EB4D /* QRImageScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRImageScanner.swift; sourceTree = "<group>"; };
-        B36EFD352298617C002753B2 /* UIButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIButton.swift; sourceTree = "<group>"; };
-        B379BA6423E2A2F1002CA92E /* SingleToMultiWalletMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleToMultiWalletMigration.swift; sourceTree = "<group>"; };
-        B37AD0A22408870B00C83D80 /* WalletAccountView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = WalletAccountView.xib; sourceTree = "<group>"; };
-        B37AD0A424088A6700C83D80 /* WalletAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletAccountView.swift; sourceTree = "<group>"; };
-        B3967B3C22A75BD400E14432 /* UITableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITableView.swift; sourceTree = "<group>"; };
-        B39BDC4C228F798300F3FB55 /* BuildConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildConfig.swift; sourceTree = "<group>"; };
-        B3A3EF8522936BFE00008A4E /* Reachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
-        B3A3EF87229375D100008A4E /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
-        B3A3EF912295956300008A4E /* SendViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendViewController.swift; sourceTree = "<group>"; };
-        B3A8E80923E593720094957B /* CheckableListOptionTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CheckableListOptionTableViewCell.xib; sourceTree = "<group>"; };
-        B3B4698F228F0C2D00A68EDD /* Decred Wallet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Decred Wallet.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-        B3B46992228F0C2E00A68EDD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-        B3B46999228F0C2E00A68EDD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-        B3B4699C228F0C2E00A68EDD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-        B3B4699E228F0C2E00A68EDD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-        B3B469A8228F0F2600A68EDD /* UIColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
-        B3B469A9228F0F2600A68EDD /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
-        B3B469AA228F0F2600A68EDD /* String.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
-        B3B469AB228F0F2600A68EDD /* UIViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewController.swift; sourceTree = "<group>"; };
-        B3B469AD228F0F2600A68EDD /* Button.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Button.swift; sourceTree = "<group>"; };
-        B3B469B1228F0F2600A68EDD /* inconsolata_regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = inconsolata_regular.ttf; sourceTree = "<group>"; };
-        B3B469B3228F0F2600A68EDD /* SourceSansPro-BlackItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-BlackItalic.ttf"; sourceTree = "<group>"; };
-        B3B469B4228F0F2600A68EDD /* SourceSansPro-SemiBoldItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-SemiBoldItalic.ttf"; sourceTree = "<group>"; };
-        B3B469B5228F0F2600A68EDD /* SourceSansPro-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-Regular.ttf"; sourceTree = "<group>"; };
-        B3B469B6228F0F2600A68EDD /* SourceSansPro-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-Bold.ttf"; sourceTree = "<group>"; };
-        B3B469B7228F0F2600A68EDD /* SourceSansPro-LightItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-LightItalic.ttf"; sourceTree = "<group>"; };
-        B3B469B8228F0F2600A68EDD /* SourceSansPro-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-Light.ttf"; sourceTree = "<group>"; };
-        B3B469B9228F0F2600A68EDD /* SourceSansPro-Black.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-Black.ttf"; sourceTree = "<group>"; };
-        B3B469BA228F0F2600A68EDD /* SourceSansPro-ExtraLight.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-ExtraLight.ttf"; sourceTree = "<group>"; };
-        B3B469BB228F0F2600A68EDD /* SourceSansPro-BoldItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-BoldItalic.ttf"; sourceTree = "<group>"; };
-        B3B469BC228F0F2600A68EDD /* SourceSansPro-SemiBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-SemiBold.ttf"; sourceTree = "<group>"; };
-        B3B469BD228F0F2600A68EDD /* SourceSansPro-ExtraLightItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-ExtraLightItalic.ttf"; sourceTree = "<group>"; };
-        B3B469BE228F0F2600A68EDD /* SourceSansPro-Italic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-Italic.ttf"; sourceTree = "<group>"; };
-        B3B469C0228F0F2600A68EDD /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
-        B3B469C1228F0F2600A68EDD /* wordlist.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = wordlist.txt; sourceTree = "<group>"; };
-        B3B469C7228F0F2600A68EDD /* UIView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
-        B3B469C8228F0F2600A68EDD /* UITableViewExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITableViewExtension.swift; sourceTree = "<group>"; };
-        B3B469C9228F0F2600A68EDD /* TextFieldDoneButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldDoneButton.swift; sourceTree = "<group>"; };
-        B3B469CD228F0F2600A68EDD /* UIImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageView.swift; sourceTree = "<group>"; };
-        B3B469CF228F0F2600A68EDD /* ContouredButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContouredButton.swift; sourceTree = "<group>"; };
-        B3B469D0228F0F2600A68EDD /* DropDownSearchField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DropDownSearchField.swift; sourceTree = "<group>"; };
-        B3B469D3228F0F2600A68EDD /* StartScreenViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StartScreenViewController.swift; sourceTree = "<group>"; };
-        B3B469D6228F0F2600A68EDD /* SecurityViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecurityViewController.swift; sourceTree = "<group>"; };
-        B3B469D8228F0F2600A68EDD /* RequestPasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestPasswordViewController.swift; sourceTree = "<group>"; };
-        B3B469DA228F0F2600A68EDD /* RequestPinViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestPinViewController.swift; sourceTree = "<group>"; };
-        B3B469DB228F0F2600A68EDD /* PinPasswordStrength.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PinPasswordStrength.swift; sourceTree = "<group>"; };
-        B3B469DC228F0F2600A68EDD /* SecurityCodeRequestBaseViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecurityCodeRequestBaseViewController.swift; sourceTree = "<group>"; };
-        B3B469EC228F0F2600A68EDD /* MenuItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuItem.swift; sourceTree = "<group>"; };
-        B3B469F1228F0F2600A68EDD /* OverviewViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverviewViewController.swift; sourceTree = "<group>"; };
-        B3B469F4228F0F2600A68EDD /* TransactionNotification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionNotification.swift; sourceTree = "<group>"; };
-        B3B469F6228F0F2600A68EDD /* WalletLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalletLoader.swift; sourceTree = "<group>"; };
-        B3B469F7228F0F2600A68EDD /* SpendingPinOrPassword.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpendingPinOrPassword.swift; sourceTree = "<group>"; };
-        B3B469F8228F0F2600A68EDD /* Dcrlibwallet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dcrlibwallet.swift; sourceTree = "<group>"; };
-        B3B469F9228F0F2600A68EDD /* StartupPinOrPassword.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StartupPinOrPassword.swift; sourceTree = "<group>"; };
-        B3B46A3B228F0F6700A68EDD /* bg-button@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bg-button@3x.png"; sourceTree = "<group>"; };
-        B3B46A3C228F0F6700A68EDD /* bg-button.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bg-button.png"; sourceTree = "<group>"; };
-        B3B46A3D228F0F6700A68EDD /* dcr-logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "dcr-logo.png"; sourceTree = "<group>"; };
-        B3B46A3E228F0F6700A68EDD /* progress bar-1s-200px.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = "progress bar-1s-200px.gif"; sourceTree = "<group>"; };
-        B3B46A49228F0F7B00A68EDD /* DropMenuButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DropMenuButton.swift; sourceTree = "<group>"; };
-        B3B46A4A228F0F7B00A68EDD /* Data.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
-        B3B46A4B228F0F7B00A68EDD /* UIIMage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIIMage.swift; sourceTree = "<group>"; };
-        B3B46A4C228F0F7B00A68EDD /* keyPadButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = keyPadButton.swift; sourceTree = "<group>"; };
-        B3B46A4D228F0F7B00A68EDD /* customUImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = customUImage.swift; sourceTree = "<group>"; };
-        B3B46A4F228F0F7B00A68EDD /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
-        B3B46A54228F0F7B00A68EDD /* ConfirmToSendFundViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfirmToSendFundViewController.swift; sourceTree = "<group>"; };
-        B3B46A5E228F0F7B00A68EDD /* TransactionDetailsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionDetailsViewController.swift; sourceTree = "<group>"; };
-        B3B46A5F228F0F7B00A68EDD /* TransactionDetails.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = TransactionDetails.storyboard; sourceTree = "<group>"; };
-        B3B46A61228F0F7B00A68EDD /* SettingsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsController.swift; sourceTree = "<group>"; };
-        B3B46A62228F0F7B00A68EDD /* PeerSetTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeerSetTableViewController.swift; sourceTree = "<group>"; };
-        B3B46A66228F0F7B00A68EDD /* WalletLogViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalletLogViewController.swift; sourceTree = "<group>"; };
-        B3B46A6F228F0F7B00A68EDD /* CurrencyConversionOptionsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CurrencyConversionOptionsViewController.swift; sourceTree = "<group>"; };
-        B3B46A75228F0F7C00A68EDD /* RecoveryWalletSeedWordCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecoveryWalletSeedWordCell.swift; sourceTree = "<group>"; };
-        B3B46A7A228F0F7C00A68EDD /* SeedCheckActiveCellView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeedCheckActiveCellView.swift; sourceTree = "<group>"; };
-        B3B46A7C228F0F7C00A68EDD /* ConfirmSeedViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfirmSeedViewCell.swift; sourceTree = "<group>"; };
-        B3B46A7F228F0F7C00A68EDD /* Storyboard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Storyboard.swift; sourceTree = "<group>"; };
-        B3B9432823E4D0B30088EC3E /* WalletSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSettingsViewController.swift; sourceTree = "<group>"; };
-        B3C03B2223DD41EE00156D9F /* Wallets.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Wallets.storyboard; sourceTree = "<group>"; };
-        B3C0D4AE23DF9C45002D984F /* Security.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Security.swift; sourceTree = "<group>"; };
-        B3C0D4B123E0DB56002D984F /* CustomDialogs.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CustomDialogs.storyboard; sourceTree = "<group>"; };
-        B3C0D4B323E0DBF6002D984F /* SimpleTextInputDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleTextInputDialog.swift; sourceTree = "<group>"; };
-        B3C0D4B523E0FBA5002D984F /* SimpleOkCancelDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleOkCancelDialog.swift; sourceTree = "<group>"; };
-        B3D21C9E2296E4F000609F23 /* ExchangeRates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRates.swift; sourceTree = "<group>"; };
-        B3D474DE23E55B5D00B6E305 /* WalletSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSettings.swift; sourceTree = "<group>"; };
-        B3D474E123E56CFD00B6E305 /* CheckableListDialogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckableListDialogViewController.swift; sourceTree = "<group>"; };
-        B3D474E323E57DA200B6E305 /* CheckableListOptionTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckableListOptionTableViewCell.swift; sourceTree = "<group>"; };
-        B3E727C323DD4A5F003B06B4 /* WalletInfoTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = WalletInfoTableViewCell.xib; sourceTree = "<group>"; };
-        B3E727C523DD4ABF003B06B4 /* WalletAccountTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = WalletAccountTableViewCell.xib; sourceTree = "<group>"; };
-        B3E727C723DD4AD7003B06B4 /* WalletInfoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletInfoTableViewCell.swift; sourceTree = "<group>"; };
-        B3E727C923DD4AE7003B06B4 /* WalletAccountTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletAccountTableViewCell.swift; sourceTree = "<group>"; };
-        B3E727CB23DD506E003B06B4 /* WalletsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletsViewController.swift; sourceTree = "<group>"; };
-        B3E727CD23DE0FCC003B06B4 /* Wallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Wallet.swift; sourceTree = "<group>"; };
-        C8BBC3AD2450CE1E001A5A9E /* SuffixTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuffixTextField.swift; sourceTree = "<group>"; };
-        D59C7DB99807D17630259A55 /* Pods-Decred Wallet.testnet release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Decred Wallet.testnet release.xcconfig"; path = "Target Support Files/Pods-Decred Wallet/Pods-Decred Wallet.testnet release.xcconfig"; sourceTree = "<group>"; };
-        DD02AC6423969440004A73E3 /* MoreMenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreMenuItem.swift; sourceTree = "<group>"; };
-        DD17D9CB23CE243D0017E41D /* RestoreExistingWalletViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RestoreExistingWalletViewController.swift; sourceTree = "<group>"; };
-        DD2E176D24A95BAC001AF94D /* RestoreExistingWalletUITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreExistingWalletUITest.swift; sourceTree = "<group>"; };
-        DD2E177124A95CA4001AF94D /* SeedBackupUITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedBackupUITest.swift; sourceTree = "<group>"; };
-        DD36717623B44AB700D1ED67 /* More.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = More.storyboard; sourceTree = "<group>"; };
-        DD36EE33247020C30011C335 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Localizable.strings; sourceTree = "<group>"; };
-        DD398AB725C35B03003BC77D /* PrivacySetupTypeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySetupTypeViewController.swift; sourceTree = "<group>"; };
-        DD398ABA25C35B07003BC77D /* PrivacyManualSetupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyManualSetupViewController.swift; sourceTree = "<group>"; };
-        DD3DF86522C3F0BD00E168AB /* UILabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UILabel.swift; sourceTree = "<group>"; };
-        DD3DF86722C42B3E00E168AB /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
-        DD41737C22B1B31E00580935 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
-        DD41737E22B1B32500580935 /* ru-RU */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ru-RU"; path = "ru-RU.lproj/Localizable.strings"; sourceTree = "<group>"; };
-        DD443DD422C768A000EEAB95 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Localizable.strings; sourceTree = "<group>"; };
-        DD452ED922CA93CB00A12378 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
-        DD493BF7247327E800C0D772 /* MultipleTextInputDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleTextInputDialog.swift; sourceTree = "<group>"; };
-        DD493BFF247654BC00C0D772 /* WatchOnlyWalletInfoTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = WatchOnlyWalletInfoTableViewCell.xib; sourceTree = "<group>"; };
-        DD493C01247654BC00C0D772 /* WatchOnlyWalletInfoTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WatchOnlyWalletInfoTableViewCell.swift; sourceTree = "<group>"; };
-        DD493C03247654BC00C0D772 /* WatchOnlyWalletTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WatchOnlyWalletTableViewCell.swift; sourceTree = "<group>"; };
-        DD493C05247654BC00C0D772 /* WatchOnlyWalletTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = WatchOnlyWalletTableViewCell.xib; sourceTree = "<group>"; };
-        DD4948EB22C0E400006A35F8 /* LocalizedStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedStrings.swift; sourceTree = "<group>"; };
-        DD53FD762459F8B3003CA279 /* beep.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = beep.mp3; sourceTree = "<group>"; };
-        DD569297259B9E3F004D4BE6 /* PrivacyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyViewController.swift; sourceTree = "<group>"; };
-        DD5AB14523BAE47A00863362 /* About.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = About.storyboard; sourceTree = "<group>"; };
-        DD5AB14723BAE47A00863362 /* Debug.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Debug.storyboard; sourceTree = "<group>"; };
-        DD5AB14923BAE47A00863362 /* Help.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Help.storyboard; sourceTree = "<group>"; };
-        DD5AB14B23D36F7E00863362 /* AboutTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTableViewController.swift; sourceTree = "<group>"; };
-        DD5AB14D23D4C12C00863362 /* DebugTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugTableViewController.swift; sourceTree = "<group>"; };
-        DD5AB14F23D612C800863362 /* HelpTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpTableViewController.swift; sourceTree = "<group>"; };
-        DD67443725CA321C001AD0B5 /* ToolTipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolTipView.swift; sourceTree = "<group>"; };
-        DD81CBC223B39DF1009D3833 /* FloatingLabelTextInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingLabelTextInput.swift; sourceTree = "<group>"; };
-        DD81CBC423B39E6A009D3833 /* PaddedLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddedLabel.swift; sourceTree = "<group>"; };
-        DD81CBC723B3A219009D3833 /* ValidateAddresses.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ValidateAddresses.storyboard; sourceTree = "<group>"; };
-        DD81CBC923B3A298009D3833 /* ValidateAddressesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidateAddressesViewController.swift; sourceTree = "<group>"; };
-        DD89A04023B0842400C1ECE9 /* SecurityTools.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SecurityTools.storyboard; sourceTree = "<group>"; };
-        DD89A04223B08CF800C1ECE9 /* SecurityToolsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityToolsViewController.swift; sourceTree = "<group>"; };
-        DD89A04423B08FDD00C1ECE9 /* SecurityToolsItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityToolsItem.swift; sourceTree = "<group>"; };
-        DD89A04623B091FF00C1ECE9 /* SecurityToolsItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityToolsItemCell.swift; sourceTree = "<group>"; };
-        DD8F9D3B22BE7A5600FF8594 /* Security.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Security.storyboard; sourceTree = "<group>"; };
-        DDA2F7CD24375FEF00A3DC7C /* StatisticsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsViewController.swift; sourceTree = "<group>"; };
-        DDA8154A243E56740011333F /* WalletSetup.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = WalletSetup.storyboard; sourceTree = "<group>"; };
-        DDA8734D245F69C00029A13D /* CIImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIImage.swift; sourceTree = "<group>"; };
-        DDAE90FF2435086B00FEC016 /* KeychainWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainWrapper.swift; sourceTree = "<group>"; };
-        DDAE91012435092200FEC016 /* KeychainItemAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainItemAccessibility.swift; sourceTree = "<group>"; };
-        DDAE91032435092200FEC016 /* ErrorMessageForLA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMessageForLA.swift; sourceTree = "<group>"; };
-        DDB660F22486BABB0060B0C5 /* Decred WalletUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Decred WalletUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-        DDB660F42486BABB0060B0C5 /* Decred_WalletUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Decred_WalletUITests.swift; sourceTree = "<group>"; };
-        DDB660F62486BABB0060B0C5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-        DDCF259922B8A346005FCBB9 /* Overview.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Overview.storyboard; sourceTree = "<group>"; };
-        DDCF259B22B8A361005FCBB9 /* Send.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Send.storyboard; sourceTree = "<group>"; };
-        DDCF25A022B8A3D4005FCBB9 /* Settings.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Settings.storyboard; sourceTree = "<group>"; };
-        DDCF25A822B8A487005FCBB9 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
-        DDD65AD622A935460027CDA8 /* LicenseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicenseViewController.swift; sourceTree = "<group>"; };
-        DDD7D20825C1BCCB0013BF0A /* Privacy.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Privacy.storyboard; sourceTree = "<group>"; };
-        DDDF95CB23C11F760057AA7F /* VerifyMessage.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = VerifyMessage.storyboard; sourceTree = "<group>"; };
-        DDDF95CD23C11F760057AA7F /* VerifyMessageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyMessageViewController.swift; sourceTree = "<group>"; };
-        DDDF95D423C20AA70057AA7F /* SignMessage.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SignMessage.storyboard; sourceTree = "<group>"; };
-        DDDF95D623C20AA70057AA7F /* SignMessageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignMessageViewController.swift; sourceTree = "<group>"; };
-        DDE2374523BA386C00C2A94F /* MoreMenuViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MoreMenuViewController.swift; sourceTree = "<group>"; };
-        DDE2374723BA386C00C2A94F /* MoreMenuItemCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MoreMenuItemCell.swift; sourceTree = "<group>"; };
-        DDEEEE1725AB1B8E00794B67 /* PrivacySetupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySetupViewController.swift; sourceTree = "<group>"; };
-        DDFB922722C8FF2D00F46FBE /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		100B122523E9EEAC005636A7 /* TransactionTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TransactionTableViewCell.xib; sourceTree = "<group>"; };
+		100B122623E9EEAC005636A7 /* TransactionTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionTableViewCell.swift; sourceTree = "<group>"; };
+		100B122723E9EEAC005636A7 /* Transactions.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Transactions.storyboard; sourceTree = "<group>"; };
+		100B122823E9EEAC005636A7 /* TransactionsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionsViewController.swift; sourceTree = "<group>"; };
+		100B122D23E9EECB005636A7 /* RestoreExistingWalletSuccessViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RestoreExistingWalletSuccessViewController.swift; sourceTree = "<group>"; };
+		102AFAC323AA2B4D007E2EBD /* ProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressView.swift; sourceTree = "<group>"; };
+		102D724723ED5271002DCAF2 /* TransactionDetailCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionDetailCell.swift; sourceTree = "<group>"; };
+		10341E0023CBBB700055DFDE /* SeedBackupSuccessViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeedBackupSuccessViewController.swift; sourceTree = "<group>"; };
+		10341E0123CBBB700055DFDE /* SeedWordsDisplayViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeedWordsDisplayViewController.swift; sourceTree = "<group>"; };
+		10341E0223CBBB700055DFDE /* SeedBackupVerifyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeedBackupVerifyViewController.swift; sourceTree = "<group>"; };
+		10341E0323CBBB700055DFDE /* SeedBackupVerifyTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeedBackupVerifyTableViewCell.swift; sourceTree = "<group>"; };
+		10341E0423CBBB700055DFDE /* SeedWordsDisplayTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeedWordsDisplayTableViewCell.swift; sourceTree = "<group>"; };
+		10341E0523CBBB700055DFDE /* SeedBackup.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = SeedBackup.storyboard; sourceTree = "<group>"; };
+		10341E0623CBBB700055DFDE /* SeedBackupReminderViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeedBackupReminderViewController.swift; sourceTree = "<group>"; };
+		10341E0E23CBBB7E0055DFDE /* Label.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Label.swift; sourceTree = "<group>"; };
+		1034D5CE24113BF10009576C /* SimpleAlertDialog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimpleAlertDialog.swift; sourceTree = "<group>"; };
+		103BE67D240D1F9E007910DA /* WalletSelectorCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSelectorCollectionViewCell.swift; sourceTree = "<group>"; };
+		105836B623EACD390030FDF2 /* ReceiveViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReceiveViewController.swift; sourceTree = "<group>"; };
+		105836B723EACD390030FDF2 /* Receive.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Receive.storyboard; sourceTree = "<group>"; };
+		108A2E7323DE311900B13A22 /* SelfSizedTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelfSizedTableView.swift; sourceTree = "<group>"; };
+		10945CD923F3DB0C00BBE242 /* TransactionOverviewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionOverviewCell.swift; sourceTree = "<group>"; };
+		10B7818023F066DA00AD2709 /* TransactionInputDetailCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionInputDetailCell.swift; sourceTree = "<group>"; };
+		10B7818423F0693C00AD2709 /* TransactionOutputDetailCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionOutputDetailCell.swift; sourceTree = "<group>"; };
+		10BA77982390059F00B67446 /* TabMenuItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabMenuItemView.swift; sourceTree = "<group>"; };
+		10C6610B23EC587B00754DED /* AccountSelectorDialog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountSelectorDialog.swift; sourceTree = "<group>"; };
+		10C6610C23EC587B00754DED /* AccountSelectorTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AccountSelectorTableViewCell.xib; sourceTree = "<group>"; };
+		10C6610D23EC587B00754DED /* AccountSelectorTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountSelectorTableViewCell.swift; sourceTree = "<group>"; };
+		10D9FB8E23C3956200CBF216 /* FloatingPlaceholderTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatingPlaceholderTextField.swift; sourceTree = "<group>"; };
+		10D9FB9123C3956300CBF216 /* FloatingPlaceholderLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatingPlaceholderLabel.swift; sourceTree = "<group>"; };
+		10FABE4A23C72D6700BC201B /* FloatingPlaceholderInputProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatingPlaceholderInputProtocol.swift; sourceTree = "<group>"; };
+		10FABE4E23C7303E00BC201B /* FloatingPlaceholderTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatingPlaceholderTextView.swift; sourceTree = "<group>"; };
+		10FABE5023C7307100BC201B /* FloatingPlaceholderBorderLayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatingPlaceholderBorderLayer.swift; sourceTree = "<group>"; };
+		23F5A25CDDC0ADF47F98ED95 /* Pods-Decred Wallet.mainnet release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Decred Wallet.mainnet release.xcconfig"; path = "Target Support Files/Pods-Decred Wallet/Pods-Decred Wallet.mainnet release.xcconfig"; sourceTree = "<group>"; };
+		250D77BC23F2BF0F00CDC256 /* DecredAddressURI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecredAddressURI.swift; sourceTree = "<group>"; };
+		2557E1882355C6FA00B6A1B7 /* NavigationMenuTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationMenuTabBarController.swift; sourceTree = "<group>"; };
+		2557E18A2355C9F000B6A1B7 /* CustomTabMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTabMenuView.swift; sourceTree = "<group>"; };
+		25751F522372C9460019F657 /* Dcrlibwallet.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Dcrlibwallet.framework; path = libs/Dcrlibwallet.framework; sourceTree = "<group>"; };
+		25A4331B2373D0330018FFCF /* SyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncManager.swift; sourceTree = "<group>"; };
+		25E63F4D23312B2B009CD53E /* NavMenuFloatingButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavMenuFloatingButtons.swift; sourceTree = "<group>"; };
+		6004FFB725CC5D0100D5A25C /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
+		6007D38A24F406AA000EC5CB /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
+		6007D38C24F42089000EC5CB /* PoliteiaNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoliteiaNotification.swift; sourceTree = "<group>"; };
+		60778ADF26274DA9006B1FC2 /* WalletMixerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletMixerCell.swift; sourceTree = "<group>"; };
+		6091E9A8255000CE0028E67F /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		60C7E54024ED8738009E4569 /* PlainHorizontalProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainHorizontalProgressBar.swift; sourceTree = "<group>"; };
+		60C7E54324ED88B8009E4569 /* Politeia.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Politeia.storyboard; sourceTree = "<group>"; };
+		60C7E54424ED88B8009E4569 /* PoliteiaTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PoliteiaTableViewCell.swift; sourceTree = "<group>"; };
+		60C7E54524ED88B8009E4569 /* PoliteiaController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PoliteiaController.swift; sourceTree = "<group>"; };
+		60C7E54924ED88F0009E4569 /* PoliteiaStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PoliteiaStatus.swift; sourceTree = "<group>"; };
+		60C7E54A24ED88F0009E4569 /* Politeia.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Politeia.swift; sourceTree = "<group>"; };
+		60DFF5D024F75D4500624161 /* PoliteiaDetailController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoliteiaDetailController.swift; sourceTree = "<group>"; };
+		60E8539F25B324C800E4CFDD /* ConnectedPeerViewcontroller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedPeerViewcontroller.swift; sourceTree = "<group>"; };
+		60E853A325B4805200E4CFDD /* PeerInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerInfo.swift; sourceTree = "<group>"; };
+		60E853A725B48F9800E4CFDD /* ConnectedPeerTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedPeerTableViewCell.swift; sourceTree = "<group>"; };
+		6A0625AB1C6ACD2EC77F544F /* Pods-Decred Wallet.mainnet debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Decred Wallet.mainnet debug.xcconfig"; path = "Target Support Files/Pods-Decred Wallet/Pods-Decred Wallet.mainnet debug.xcconfig"; sourceTree = "<group>"; };
+		A9714AB438E597D403032748 /* Pods_Decred_Wallet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Decred_Wallet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AD24C23C2343E445009583C9 /* NotificationsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsManager.swift; sourceTree = "<group>"; };
+		B107091A1D996651AB5D8891 /* Pods-Decred Wallet.testnet debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Decred Wallet.testnet debug.xcconfig"; path = "Target Support Files/Pods-Decred Wallet/Pods-Decred Wallet.testnet debug.xcconfig"; sourceTree = "<group>"; };
+		B304B39323F202A400B81798 /* Settings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
+		B32EB42D23EEA24000E43D4F /* AccountDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDetailsViewController.swift; sourceTree = "<group>"; };
+		B3456D2423D91CF600B04860 /* RoundedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedView.swift; sourceTree = "<group>"; };
+		B34A2F8E23E8E90500B8BC01 /* WalletSyncDetailsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSyncDetailsTableViewCell.swift; sourceTree = "<group>"; };
+		B34A2F9023E8ED1500B8BC01 /* MultiWalletSyncDetailsLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiWalletSyncDetailsLoader.swift; sourceTree = "<group>"; };
+		B35C55D7232FED610006A765 /* Transaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transaction.swift; sourceTree = "<group>"; };
+		B3635B81229FE5870052EB4D /* QRImageScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRImageScanner.swift; sourceTree = "<group>"; };
+		B36EFD352298617C002753B2 /* UIButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIButton.swift; sourceTree = "<group>"; };
+		B379BA6423E2A2F1002CA92E /* SingleToMultiWalletMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleToMultiWalletMigration.swift; sourceTree = "<group>"; };
+		B37AD0A22408870B00C83D80 /* WalletAccountView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = WalletAccountView.xib; sourceTree = "<group>"; };
+		B37AD0A424088A6700C83D80 /* WalletAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletAccountView.swift; sourceTree = "<group>"; };
+		B3967B3C22A75BD400E14432 /* UITableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITableView.swift; sourceTree = "<group>"; };
+		B39BDC4C228F798300F3FB55 /* BuildConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildConfig.swift; sourceTree = "<group>"; };
+		B3A3EF8522936BFE00008A4E /* Reachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
+		B3A3EF87229375D100008A4E /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
+		B3A3EF912295956300008A4E /* SendViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendViewController.swift; sourceTree = "<group>"; };
+		B3A8E80923E593720094957B /* CheckableListOptionTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CheckableListOptionTableViewCell.xib; sourceTree = "<group>"; };
+		B3B4698F228F0C2D00A68EDD /* Decred Wallet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Decred Wallet.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B3B46992228F0C2E00A68EDD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		B3B46999228F0C2E00A68EDD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B3B4699C228F0C2E00A68EDD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		B3B4699E228F0C2E00A68EDD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B3B469A8228F0F2600A68EDD /* UIColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
+		B3B469A9228F0F2600A68EDD /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
+		B3B469AA228F0F2600A68EDD /* String.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
+		B3B469AB228F0F2600A68EDD /* UIViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewController.swift; sourceTree = "<group>"; };
+		B3B469AD228F0F2600A68EDD /* Button.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Button.swift; sourceTree = "<group>"; };
+		B3B469B1228F0F2600A68EDD /* inconsolata_regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = inconsolata_regular.ttf; sourceTree = "<group>"; };
+		B3B469B3228F0F2600A68EDD /* SourceSansPro-BlackItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-BlackItalic.ttf"; sourceTree = "<group>"; };
+		B3B469B4228F0F2600A68EDD /* SourceSansPro-SemiBoldItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-SemiBoldItalic.ttf"; sourceTree = "<group>"; };
+		B3B469B5228F0F2600A68EDD /* SourceSansPro-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-Regular.ttf"; sourceTree = "<group>"; };
+		B3B469B6228F0F2600A68EDD /* SourceSansPro-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-Bold.ttf"; sourceTree = "<group>"; };
+		B3B469B7228F0F2600A68EDD /* SourceSansPro-LightItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-LightItalic.ttf"; sourceTree = "<group>"; };
+		B3B469B8228F0F2600A68EDD /* SourceSansPro-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-Light.ttf"; sourceTree = "<group>"; };
+		B3B469B9228F0F2600A68EDD /* SourceSansPro-Black.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-Black.ttf"; sourceTree = "<group>"; };
+		B3B469BA228F0F2600A68EDD /* SourceSansPro-ExtraLight.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-ExtraLight.ttf"; sourceTree = "<group>"; };
+		B3B469BB228F0F2600A68EDD /* SourceSansPro-BoldItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-BoldItalic.ttf"; sourceTree = "<group>"; };
+		B3B469BC228F0F2600A68EDD /* SourceSansPro-SemiBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-SemiBold.ttf"; sourceTree = "<group>"; };
+		B3B469BD228F0F2600A68EDD /* SourceSansPro-ExtraLightItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-ExtraLightItalic.ttf"; sourceTree = "<group>"; };
+		B3B469BE228F0F2600A68EDD /* SourceSansPro-Italic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-Italic.ttf"; sourceTree = "<group>"; };
+		B3B469C0228F0F2600A68EDD /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		B3B469C1228F0F2600A68EDD /* wordlist.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = wordlist.txt; sourceTree = "<group>"; };
+		B3B469C7228F0F2600A68EDD /* UIView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
+		B3B469C8228F0F2600A68EDD /* UITableViewExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITableViewExtension.swift; sourceTree = "<group>"; };
+		B3B469C9228F0F2600A68EDD /* TextFieldDoneButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldDoneButton.swift; sourceTree = "<group>"; };
+		B3B469CD228F0F2600A68EDD /* UIImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageView.swift; sourceTree = "<group>"; };
+		B3B469CF228F0F2600A68EDD /* ContouredButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContouredButton.swift; sourceTree = "<group>"; };
+		B3B469D0228F0F2600A68EDD /* DropDownSearchField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DropDownSearchField.swift; sourceTree = "<group>"; };
+		B3B469D3228F0F2600A68EDD /* StartScreenViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StartScreenViewController.swift; sourceTree = "<group>"; };
+		B3B469D6228F0F2600A68EDD /* SecurityViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecurityViewController.swift; sourceTree = "<group>"; };
+		B3B469D8228F0F2600A68EDD /* RequestPasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestPasswordViewController.swift; sourceTree = "<group>"; };
+		B3B469DA228F0F2600A68EDD /* RequestPinViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestPinViewController.swift; sourceTree = "<group>"; };
+		B3B469DB228F0F2600A68EDD /* PinPasswordStrength.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PinPasswordStrength.swift; sourceTree = "<group>"; };
+		B3B469DC228F0F2600A68EDD /* SecurityCodeRequestBaseViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecurityCodeRequestBaseViewController.swift; sourceTree = "<group>"; };
+		B3B469EC228F0F2600A68EDD /* MenuItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuItem.swift; sourceTree = "<group>"; };
+		B3B469F1228F0F2600A68EDD /* OverviewViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverviewViewController.swift; sourceTree = "<group>"; };
+		B3B469F4228F0F2600A68EDD /* TransactionNotification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionNotification.swift; sourceTree = "<group>"; };
+		B3B469F6228F0F2600A68EDD /* WalletLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalletLoader.swift; sourceTree = "<group>"; };
+		B3B469F7228F0F2600A68EDD /* SpendingPinOrPassword.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpendingPinOrPassword.swift; sourceTree = "<group>"; };
+		B3B469F8228F0F2600A68EDD /* Dcrlibwallet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dcrlibwallet.swift; sourceTree = "<group>"; };
+		B3B469F9228F0F2600A68EDD /* StartupPinOrPassword.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StartupPinOrPassword.swift; sourceTree = "<group>"; };
+		B3B46A3B228F0F6700A68EDD /* bg-button@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bg-button@3x.png"; sourceTree = "<group>"; };
+		B3B46A3C228F0F6700A68EDD /* bg-button.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bg-button.png"; sourceTree = "<group>"; };
+		B3B46A3D228F0F6700A68EDD /* dcr-logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "dcr-logo.png"; sourceTree = "<group>"; };
+		B3B46A3E228F0F6700A68EDD /* progress bar-1s-200px.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = "progress bar-1s-200px.gif"; sourceTree = "<group>"; };
+		B3B46A49228F0F7B00A68EDD /* DropMenuButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DropMenuButton.swift; sourceTree = "<group>"; };
+		B3B46A4A228F0F7B00A68EDD /* Data.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
+		B3B46A4B228F0F7B00A68EDD /* UIIMage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIIMage.swift; sourceTree = "<group>"; };
+		B3B46A4C228F0F7B00A68EDD /* keyPadButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = keyPadButton.swift; sourceTree = "<group>"; };
+		B3B46A4D228F0F7B00A68EDD /* customUImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = customUImage.swift; sourceTree = "<group>"; };
+		B3B46A4F228F0F7B00A68EDD /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
+		B3B46A54228F0F7B00A68EDD /* ConfirmToSendFundViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfirmToSendFundViewController.swift; sourceTree = "<group>"; };
+		B3B46A5E228F0F7B00A68EDD /* TransactionDetailsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionDetailsViewController.swift; sourceTree = "<group>"; };
+		B3B46A5F228F0F7B00A68EDD /* TransactionDetails.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = TransactionDetails.storyboard; sourceTree = "<group>"; };
+		B3B46A61228F0F7B00A68EDD /* SettingsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsController.swift; sourceTree = "<group>"; };
+		B3B46A62228F0F7B00A68EDD /* PeerSetTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeerSetTableViewController.swift; sourceTree = "<group>"; };
+		B3B46A66228F0F7B00A68EDD /* WalletLogViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalletLogViewController.swift; sourceTree = "<group>"; };
+		B3B46A6F228F0F7B00A68EDD /* CurrencyConversionOptionsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CurrencyConversionOptionsViewController.swift; sourceTree = "<group>"; };
+		B3B46A75228F0F7C00A68EDD /* RecoveryWalletSeedWordCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecoveryWalletSeedWordCell.swift; sourceTree = "<group>"; };
+		B3B46A7A228F0F7C00A68EDD /* SeedCheckActiveCellView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeedCheckActiveCellView.swift; sourceTree = "<group>"; };
+		B3B46A7C228F0F7C00A68EDD /* ConfirmSeedViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfirmSeedViewCell.swift; sourceTree = "<group>"; };
+		B3B46A7F228F0F7C00A68EDD /* Storyboard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Storyboard.swift; sourceTree = "<group>"; };
+		B3B9432823E4D0B30088EC3E /* WalletSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSettingsViewController.swift; sourceTree = "<group>"; };
+		B3C03B2223DD41EE00156D9F /* Wallets.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Wallets.storyboard; sourceTree = "<group>"; };
+		B3C0D4AE23DF9C45002D984F /* Security.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Security.swift; sourceTree = "<group>"; };
+		B3C0D4B123E0DB56002D984F /* CustomDialogs.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CustomDialogs.storyboard; sourceTree = "<group>"; };
+		B3C0D4B323E0DBF6002D984F /* SimpleTextInputDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleTextInputDialog.swift; sourceTree = "<group>"; };
+		B3C0D4B523E0FBA5002D984F /* SimpleOkCancelDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleOkCancelDialog.swift; sourceTree = "<group>"; };
+		B3D21C9E2296E4F000609F23 /* ExchangeRates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRates.swift; sourceTree = "<group>"; };
+		B3D474DE23E55B5D00B6E305 /* WalletSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSettings.swift; sourceTree = "<group>"; };
+		B3D474E123E56CFD00B6E305 /* CheckableListDialogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckableListDialogViewController.swift; sourceTree = "<group>"; };
+		B3D474E323E57DA200B6E305 /* CheckableListOptionTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckableListOptionTableViewCell.swift; sourceTree = "<group>"; };
+		B3E727C323DD4A5F003B06B4 /* WalletInfoTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = WalletInfoTableViewCell.xib; sourceTree = "<group>"; };
+		B3E727C523DD4ABF003B06B4 /* WalletAccountTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = WalletAccountTableViewCell.xib; sourceTree = "<group>"; };
+		B3E727C723DD4AD7003B06B4 /* WalletInfoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletInfoTableViewCell.swift; sourceTree = "<group>"; };
+		B3E727C923DD4AE7003B06B4 /* WalletAccountTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletAccountTableViewCell.swift; sourceTree = "<group>"; };
+		B3E727CB23DD506E003B06B4 /* WalletsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletsViewController.swift; sourceTree = "<group>"; };
+		B3E727CD23DE0FCC003B06B4 /* Wallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Wallet.swift; sourceTree = "<group>"; };
+		C8BBC3AD2450CE1E001A5A9E /* SuffixTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuffixTextField.swift; sourceTree = "<group>"; };
+		D59C7DB99807D17630259A55 /* Pods-Decred Wallet.testnet release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Decred Wallet.testnet release.xcconfig"; path = "Target Support Files/Pods-Decred Wallet/Pods-Decred Wallet.testnet release.xcconfig"; sourceTree = "<group>"; };
+		DD02AC6423969440004A73E3 /* MoreMenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreMenuItem.swift; sourceTree = "<group>"; };
+		DD17D9CB23CE243D0017E41D /* RestoreExistingWalletViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RestoreExistingWalletViewController.swift; sourceTree = "<group>"; };
+		DD2E176D24A95BAC001AF94D /* RestoreExistingWalletUITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreExistingWalletUITest.swift; sourceTree = "<group>"; };
+		DD2E177124A95CA4001AF94D /* SeedBackupUITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedBackupUITest.swift; sourceTree = "<group>"; };
+		DD36717623B44AB700D1ED67 /* More.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = More.storyboard; sourceTree = "<group>"; };
+		DD36EE33247020C30011C335 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DD398AB725C35B03003BC77D /* PrivacySetupTypeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySetupTypeViewController.swift; sourceTree = "<group>"; };
+		DD398ABA25C35B07003BC77D /* PrivacyManualSetupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyManualSetupViewController.swift; sourceTree = "<group>"; };
+		DD3DF86522C3F0BD00E168AB /* UILabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UILabel.swift; sourceTree = "<group>"; };
+		DD3DF86722C42B3E00E168AB /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		DD41737C22B1B31E00580935 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DD41737E22B1B32500580935 /* ru-RU */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ru-RU"; path = "ru-RU.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		DD443DD422C768A000EEAB95 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DD452ED922CA93CB00A12378 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DD493BF7247327E800C0D772 /* MultipleTextInputDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleTextInputDialog.swift; sourceTree = "<group>"; };
+		DD493BFF247654BC00C0D772 /* WatchOnlyWalletInfoTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = WatchOnlyWalletInfoTableViewCell.xib; sourceTree = "<group>"; };
+		DD493C01247654BC00C0D772 /* WatchOnlyWalletInfoTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WatchOnlyWalletInfoTableViewCell.swift; sourceTree = "<group>"; };
+		DD493C03247654BC00C0D772 /* WatchOnlyWalletTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WatchOnlyWalletTableViewCell.swift; sourceTree = "<group>"; };
+		DD493C05247654BC00C0D772 /* WatchOnlyWalletTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = WatchOnlyWalletTableViewCell.xib; sourceTree = "<group>"; };
+		DD4948EB22C0E400006A35F8 /* LocalizedStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedStrings.swift; sourceTree = "<group>"; };
+		DD53FD762459F8B3003CA279 /* beep.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = beep.mp3; sourceTree = "<group>"; };
+		DD569297259B9E3F004D4BE6 /* PrivacyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyViewController.swift; sourceTree = "<group>"; };
+		DD5AB14523BAE47A00863362 /* About.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = About.storyboard; sourceTree = "<group>"; };
+		DD5AB14723BAE47A00863362 /* Debug.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Debug.storyboard; sourceTree = "<group>"; };
+		DD5AB14923BAE47A00863362 /* Help.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Help.storyboard; sourceTree = "<group>"; };
+		DD5AB14B23D36F7E00863362 /* AboutTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTableViewController.swift; sourceTree = "<group>"; };
+		DD5AB14D23D4C12C00863362 /* DebugTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugTableViewController.swift; sourceTree = "<group>"; };
+		DD5AB14F23D612C800863362 /* HelpTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpTableViewController.swift; sourceTree = "<group>"; };
+		DD67443725CA321C001AD0B5 /* ToolTipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolTipView.swift; sourceTree = "<group>"; };
+		DD81CBC223B39DF1009D3833 /* FloatingLabelTextInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingLabelTextInput.swift; sourceTree = "<group>"; };
+		DD81CBC423B39E6A009D3833 /* PaddedLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddedLabel.swift; sourceTree = "<group>"; };
+		DD81CBC723B3A219009D3833 /* ValidateAddresses.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ValidateAddresses.storyboard; sourceTree = "<group>"; };
+		DD81CBC923B3A298009D3833 /* ValidateAddressesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidateAddressesViewController.swift; sourceTree = "<group>"; };
+		DD89A04023B0842400C1ECE9 /* SecurityTools.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SecurityTools.storyboard; sourceTree = "<group>"; };
+		DD89A04223B08CF800C1ECE9 /* SecurityToolsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityToolsViewController.swift; sourceTree = "<group>"; };
+		DD89A04423B08FDD00C1ECE9 /* SecurityToolsItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityToolsItem.swift; sourceTree = "<group>"; };
+		DD89A04623B091FF00C1ECE9 /* SecurityToolsItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityToolsItemCell.swift; sourceTree = "<group>"; };
+		DD8F9D3B22BE7A5600FF8594 /* Security.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Security.storyboard; sourceTree = "<group>"; };
+		DDA2F7CD24375FEF00A3DC7C /* StatisticsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsViewController.swift; sourceTree = "<group>"; };
+		DDA8154A243E56740011333F /* WalletSetup.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = WalletSetup.storyboard; sourceTree = "<group>"; };
+		DDA8734D245F69C00029A13D /* CIImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIImage.swift; sourceTree = "<group>"; };
+		DDAE90FF2435086B00FEC016 /* KeychainWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainWrapper.swift; sourceTree = "<group>"; };
+		DDAE91012435092200FEC016 /* KeychainItemAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainItemAccessibility.swift; sourceTree = "<group>"; };
+		DDAE91032435092200FEC016 /* ErrorMessageForLA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMessageForLA.swift; sourceTree = "<group>"; };
+		DDB660F22486BABB0060B0C5 /* Decred WalletUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Decred WalletUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		DDB660F42486BABB0060B0C5 /* Decred_WalletUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Decred_WalletUITests.swift; sourceTree = "<group>"; };
+		DDB660F62486BABB0060B0C5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DDCF259922B8A346005FCBB9 /* Overview.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Overview.storyboard; sourceTree = "<group>"; };
+		DDCF259B22B8A361005FCBB9 /* Send.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Send.storyboard; sourceTree = "<group>"; };
+		DDCF25A022B8A3D4005FCBB9 /* Settings.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Settings.storyboard; sourceTree = "<group>"; };
+		DDCF25A822B8A487005FCBB9 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
+		DDD65AD622A935460027CDA8 /* LicenseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicenseViewController.swift; sourceTree = "<group>"; };
+		DDD7D20825C1BCCB0013BF0A /* Privacy.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Privacy.storyboard; sourceTree = "<group>"; };
+		DDDF95CB23C11F760057AA7F /* VerifyMessage.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = VerifyMessage.storyboard; sourceTree = "<group>"; };
+		DDDF95CD23C11F760057AA7F /* VerifyMessageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyMessageViewController.swift; sourceTree = "<group>"; };
+		DDDF95D423C20AA70057AA7F /* SignMessage.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SignMessage.storyboard; sourceTree = "<group>"; };
+		DDDF95D623C20AA70057AA7F /* SignMessageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignMessageViewController.swift; sourceTree = "<group>"; };
+		DDE2374523BA386C00C2A94F /* MoreMenuViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MoreMenuViewController.swift; sourceTree = "<group>"; };
+		DDE2374723BA386C00C2A94F /* MoreMenuItemCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MoreMenuItemCell.swift; sourceTree = "<group>"; };
+		DDEEEE1725AB1B8E00794B67 /* PrivacySetupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySetupViewController.swift; sourceTree = "<group>"; };
+		DDFB922722C8FF2D00F46FBE /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-        B3B4698C228F0C2D00A68EDD /* Frameworks */ = {
-            isa = PBXFrameworksBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-                25751F532372C9460019F657 /* Dcrlibwallet.framework in Frameworks */,
-                B164982429AEDD7AF8C8782C /* Pods_Decred_Wallet.framework in Frameworks */,
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-        };
-        DDB660EF2486BABB0060B0C5 /* Frameworks */ = {
-            isa = PBXFrameworksBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-        };
+		B3B4698C228F0C2D00A68EDD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				25751F532372C9460019F657 /* Dcrlibwallet.framework in Frameworks */,
+				B164982429AEDD7AF8C8782C /* Pods_Decred_Wallet.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DDB660EF2486BABB0060B0C5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-        100B122423E9EEAC005636A7 /* Transactions */ = {
-            isa = PBXGroup;
-            children = (
-                100B122723E9EEAC005636A7 /* Transactions.storyboard */,
-                100B122823E9EEAC005636A7 /* TransactionsViewController.swift */,
-                100B122523E9EEAC005636A7 /* TransactionTableViewCell.xib */,
-                100B122623E9EEAC005636A7 /* TransactionTableViewCell.swift */,
-                103BE67D240D1F9E007910DA /* WalletSelectorCollectionViewCell.swift */,
-            );
-            path = Transactions;
-            sourceTree = "<group>";
-        };
-        10341DFF23CBBB700055DFDE /* Seed Backup */ = {
-            isa = PBXGroup;
-            children = (
-                10341E0523CBBB700055DFDE /* SeedBackup.storyboard */,
-                10341E0623CBBB700055DFDE /* SeedBackupReminderViewController.swift */,
-                10341E0123CBBB700055DFDE /* SeedWordsDisplayViewController.swift */,
-                10341E0023CBBB700055DFDE /* SeedBackupSuccessViewController.swift */,
-                10341E0223CBBB700055DFDE /* SeedBackupVerifyViewController.swift */,
-                10341E0323CBBB700055DFDE /* SeedBackupVerifyTableViewCell.swift */,
-                10341E0423CBBB700055DFDE /* SeedWordsDisplayTableViewCell.swift */,
-            );
-            path = "Seed Backup";
-            sourceTree = "<group>";
-        };
-        105836B523EACD390030FDF2 /* Receive */ = {
-            isa = PBXGroup;
-            children = (
-                105836B723EACD390030FDF2 /* Receive.storyboard */,
-                105836B623EACD390030FDF2 /* ReceiveViewController.swift */,
-            );
-            path = Receive;
-            sourceTree = "<group>";
-        };
-        10C6610A23EC587B00754DED /* AccountSelectorDialog */ = {
-            isa = PBXGroup;
-            children = (
-                10C6610B23EC587B00754DED /* AccountSelectorDialog.swift */,
-                10C6610C23EC587B00754DED /* AccountSelectorTableViewCell.xib */,
-                10C6610D23EC587B00754DED /* AccountSelectorTableViewCell.swift */,
-            );
-            path = AccountSelectorDialog;
-            sourceTree = "<group>";
-        };
-        10D9FB9723C3956600CBF216 /* FloatingPlaceholderInputs */ = {
-            isa = PBXGroup;
-            children = (
-                10FABE4A23C72D6700BC201B /* FloatingPlaceholderInputProtocol.swift */,
-                10D9FB8E23C3956200CBF216 /* FloatingPlaceholderTextField.swift */,
-                10FABE4E23C7303E00BC201B /* FloatingPlaceholderTextView.swift */,
-                10D9FB9123C3956300CBF216 /* FloatingPlaceholderLabel.swift */,
-                10FABE5023C7307100BC201B /* FloatingPlaceholderBorderLayer.swift */,
-            );
-            path = FloatingPlaceholderInputs;
-            sourceTree = "<group>";
-        };
-        452B0148672C448C74CB5C1E /* Frameworks */ = {
-            isa = PBXGroup;
-            children = (
-                25751F522372C9460019F657 /* Dcrlibwallet.framework */,
-                A9714AB438E597D403032748 /* Pods_Decred_Wallet.framework */,
-            );
-            name = Frameworks;
-            sourceTree = "<group>";
-        };
-        60C7E54224ED88B8009E4569 /* Politeia */ = {
-            isa = PBXGroup;
-            children = (
-                60C7E54324ED88B8009E4569 /* Politeia.storyboard */,
-                60C7E54424ED88B8009E4569 /* PoliteiaTableViewCell.swift */,
-                60C7E54524ED88B8009E4569 /* PoliteiaController.swift */,
-                60DFF5D024F75D4500624161 /* PoliteiaDetailController.swift */,
-            );
-            path = Politeia;
-            sourceTree = "<group>";
-        };
-        8F7CDB697B0BC7D598AC1F98 /* Pods */ = {
-            isa = PBXGroup;
-            children = (
-                6A0625AB1C6ACD2EC77F544F /* Pods-Decred Wallet.mainnet debug.xcconfig */,
-                B107091A1D996651AB5D8891 /* Pods-Decred Wallet.testnet debug.xcconfig */,
-                23F5A25CDDC0ADF47F98ED95 /* Pods-Decred Wallet.mainnet release.xcconfig */,
-                D59C7DB99807D17630259A55 /* Pods-Decred Wallet.testnet release.xcconfig */,
-            );
-            path = Pods;
-            sourceTree = "<group>";
-        };
-        B36255B322A11A9500C62946 /* Security Tools */ = {
-            isa = PBXGroup;
-            children = (
-                DDDF95D323C20AA70057AA7F /* Sign Message */,
-                DDDF95C823C11F300057AA7F /* Verify Message */,
-                DD81CBC623B3A187009D3833 /* Validate Addresses */,
-                DD89A04023B0842400C1ECE9 /* SecurityTools.storyboard */,
-                DD89A04223B08CF800C1ECE9 /* SecurityToolsViewController.swift */,
-                DD89A04423B08FDD00C1ECE9 /* SecurityToolsItem.swift */,
-                DD89A04623B091FF00C1ECE9 /* SecurityToolsItemCell.swift */,
-            );
-            path = "Security Tools";
-            sourceTree = "<group>";
-        };
-        B37AD09F240885DC00C83D80 /* WalletAccountView */ = {
-            isa = PBXGroup;
-            children = (
-                B37AD0A22408870B00C83D80 /* WalletAccountView.xib */,
-                B37AD0A424088A6700C83D80 /* WalletAccountView.swift */,
-            );
-            path = WalletAccountView;
-            sourceTree = "<group>";
-        };
-        B3A3EF8422936BEF00008A4E /* Network */ = {
-            isa = PBXGroup;
-            children = (
-                B3A3EF8522936BFE00008A4E /* Reachability.swift */,
-            );
-            path = Network;
-            sourceTree = "<group>";
-        };
-        B3A3EF8922937B7500008A4E /* Utils */ = {
-            isa = PBXGroup;
-            children = (
-                250D77BC23F2BF0F00CDC256 /* DecredAddressURI.swift */,
-                B304B39323F202A400B81798 /* Settings.swift */,
-                B3B46A4F228F0F7B00A68EDD /* Utils.swift */,
-                DD4948EB22C0E400006A35F8 /* LocalizedStrings.swift */,
-                AD24C23C2343E445009583C9 /* NotificationsManager.swift */,
-                DDAE90FF2435086B00FEC016 /* KeychainWrapper.swift */,
-                DDAE91012435092200FEC016 /* KeychainItemAccessibility.swift */,
-                DDAE91032435092200FEC016 /* ErrorMessageForLA.swift */,
-            );
-            path = Utils;
-            sourceTree = "<group>";
-        };
-        B3A3EF902295955100008A4E /* Send */ = {
-            isa = PBXGroup;
-            children = (
-                DDCF259B22B8A361005FCBB9 /* Send.storyboard */,
-                B3A3EF912295956300008A4E /* SendViewController.swift */,
-                B3B46A54228F0F7B00A68EDD /* ConfirmToSendFundViewController.swift */,
-            );
-            path = Send;
-            sourceTree = "<group>";
-        };
-        B3B46986228F0C2D00A68EDD = {
-            isa = PBXGroup;
-            children = (
-                B3B46991228F0C2E00A68EDD /* Decred Wallet */,
-                DDB660F32486BABB0060B0C5 /* Decred WalletUITests */,
-                B3B46990228F0C2D00A68EDD /* Products */,
-                8F7CDB697B0BC7D598AC1F98 /* Pods */,
-                452B0148672C448C74CB5C1E /* Frameworks */,
-            );
-            sourceTree = "<group>";
-        };
-        B3B46990228F0C2D00A68EDD /* Products */ = {
-            isa = PBXGroup;
-            children = (
-                B3B4698F228F0C2D00A68EDD /* Decred Wallet.app */,
-                DDB660F22486BABB0060B0C5 /* Decred WalletUITests.xctest */,
-            );
-            name = Products;
-            sourceTree = "<group>";
-        };
-        B3B46991228F0C2E00A68EDD /* Decred Wallet */ = {
-            isa = PBXGroup;
-            children = (
-                DD41737D22B1B31E00580935 /* Localizable.strings */,
-                B3A3EF8422936BEF00008A4E /* Network */,
-                B3B469BF228F0F2600A68EDD /* Constants */,
-                B3B469AC228F0F2600A68EDD /* Custom Views */,
-                B3B469C2228F0F2600A68EDD /* DcrlibwalletTypes */,
-                B3B469A7228F0F2600A68EDD /* Extensions */,
-                B3B469C6228F0F2600A68EDD /* extra_view */,
-                B3B469D1228F0F2600A68EDD /* Features */,
-                B3B469AF228F0F2600A68EDD /* Fonts */,
-                B3B46A3A228F0F6700A68EDD /* Resources */,
-                B3B46A73228F0F7C00A68EDD /* table_view_cell */,
-                B3B46A48228F0F7B00A68EDD /* view_util */,
-                B3B469F3228F0F2600A68EDD /* Wallet Utils */,
-                B3A3EF8922937B7500008A4E /* Utils */,
-                B3B46A7F228F0F7C00A68EDD /* Storyboard.swift */,
-                DDCF25A822B8A487005FCBB9 /* Main.storyboard */,
-                B3B46992228F0C2E00A68EDD /* AppDelegate.swift */,
-                B3B46999228F0C2E00A68EDD /* Assets.xcassets */,
-                DD53FD762459F8B3003CA279 /* beep.mp3 */,
-                B3B4699B228F0C2E00A68EDD /* LaunchScreen.storyboard */,
-                B3B4699E228F0C2E00A68EDD /* Info.plist */,
-                B39BDC4C228F798300F3FB55 /* BuildConfig.swift */,
-            );
-            path = "Decred Wallet";
-            sourceTree = "<group>";
-        };
-        B3B469A7228F0F2600A68EDD /* Extensions */ = {
-            isa = PBXGroup;
-            children = (
-                DD3DF86522C3F0BD00E168AB /* UILabel.swift */,
-                B3B469F8228F0F2600A68EDD /* Dcrlibwallet.swift */,
-                B3B469A8228F0F2600A68EDD /* UIColor.swift */,
-                B3B469A9228F0F2600A68EDD /* Extensions.swift */,
-                B3B469AA228F0F2600A68EDD /* String.swift */,
-                B3B469AB228F0F2600A68EDD /* UIViewController.swift */,
-                B3A3EF87229375D100008A4E /* Date.swift */,
-                B36EFD352298617C002753B2 /* UIButton.swift */,
-                B3967B3C22A75BD400E14432 /* UITableView.swift */,
-                B3B469C7228F0F2600A68EDD /* UIView.swift */,
-                DDA8734D245F69C00029A13D /* CIImage.swift */,
-                60C7E54024ED8738009E4569 /* PlainHorizontalProgressBar.swift */,
-            );
-            path = Extensions;
-            sourceTree = "<group>";
-        };
-        B3B469AC228F0F2600A68EDD /* Custom Views */ = {
-            isa = PBXGroup;
-            children = (
-                B37AD09F240885DC00C83D80 /* WalletAccountView */,
-                10D9FB9723C3956600CBF216 /* FloatingPlaceholderInputs */,
-                B3B469AD228F0F2600A68EDD /* Button.swift */,
-                10341E0E23CBBB7E0055DFDE /* Label.swift */,
-                108A2E7323DE311900B13A22 /* SelfSizedTableView.swift */,
-                B3635B81229FE5870052EB4D /* QRImageScanner.swift */,
-                102AFAC323AA2B4D007E2EBD /* ProgressView.swift */,
-                B3456D2423D91CF600B04860 /* RoundedView.swift */,
-                DD81CBC223B39DF1009D3833 /* FloatingLabelTextInput.swift */,
-                DD81CBC423B39E6A009D3833 /* PaddedLabel.swift */,
-                C8BBC3AD2450CE1E001A5A9E /* SuffixTextField.swift */,
-                DD67443725CA321C001AD0B5 /* ToolTipView.swift */,
-                6004FFB725CC5D0100D5A25C /* LoadingView.swift */,
-            );
-            path = "Custom Views";
-            sourceTree = "<group>";
-        };
-        B3B469AF228F0F2600A68EDD /* Fonts */ = {
-            isa = PBXGroup;
-            children = (
-                B3B469B5228F0F2600A68EDD /* SourceSansPro-Regular.ttf */,
-                B3B469BC228F0F2600A68EDD /* SourceSansPro-SemiBold.ttf */,
-                B3B469B0228F0F2600A68EDD /* Inconsolata */,
-                B3B469B2228F0F2600A68EDD /* Source_Sans_Pro */,
-            );
-            path = Fonts;
-            sourceTree = "<group>";
-        };
-        B3B469B0228F0F2600A68EDD /* Inconsolata */ = {
-            isa = PBXGroup;
-            children = (
-                B3B469B1228F0F2600A68EDD /* inconsolata_regular.ttf */,
-            );
-            path = Inconsolata;
-            sourceTree = "<group>";
-        };
-        B3B469B2228F0F2600A68EDD /* Source_Sans_Pro */ = {
-            isa = PBXGroup;
-            children = (
-                B3B469B3228F0F2600A68EDD /* SourceSansPro-BlackItalic.ttf */,
-                B3B469B4228F0F2600A68EDD /* SourceSansPro-SemiBoldItalic.ttf */,
-                B3B469B6228F0F2600A68EDD /* SourceSansPro-Bold.ttf */,
-                B3B469B7228F0F2600A68EDD /* SourceSansPro-LightItalic.ttf */,
-                B3B469B8228F0F2600A68EDD /* SourceSansPro-Light.ttf */,
-                B3B469B9228F0F2600A68EDD /* SourceSansPro-Black.ttf */,
-                B3B469BA228F0F2600A68EDD /* SourceSansPro-ExtraLight.ttf */,
-                B3B469BB228F0F2600A68EDD /* SourceSansPro-BoldItalic.ttf */,
-                B3B469BD228F0F2600A68EDD /* SourceSansPro-ExtraLightItalic.ttf */,
-                B3B469BE228F0F2600A68EDD /* SourceSansPro-Italic.ttf */,
-            );
-            path = Source_Sans_Pro;
-            sourceTree = "<group>";
-        };
-        B3B469BF228F0F2600A68EDD /* Constants */ = {
-            isa = PBXGroup;
-            children = (
-                B3B469C0228F0F2600A68EDD /* Constants.swift */,
-                B3B469C1228F0F2600A68EDD /* wordlist.txt */,
-            );
-            path = Constants;
-            sourceTree = "<group>";
-        };
-        B3B469C2228F0F2600A68EDD /* DcrlibwalletTypes */ = {
-            isa = PBXGroup;
-            children = (
-                B35C55D7232FED610006A765 /* Transaction.swift */,
-                60C7E54A24ED88F0009E4569 /* Politeia.swift */,
-                60C7E54924ED88F0009E4569 /* PoliteiaStatus.swift */,
-                B3E727CD23DE0FCC003B06B4 /* Wallet.swift */,
-                6007D38A24F406AA000EC5CB /* Response.swift */,
-                60E853A325B4805200E4CFDD /* PeerInfo.swift */,
-            );
-            path = DcrlibwalletTypes;
-            sourceTree = "<group>";
-        };
-        B3B469C6228F0F2600A68EDD /* extra_view */ = {
-            isa = PBXGroup;
-            children = (
-                B3B469C8228F0F2600A68EDD /* UITableViewExtension.swift */,
-                B3B469C9228F0F2600A68EDD /* TextFieldDoneButton.swift */,
-                B3B469CD228F0F2600A68EDD /* UIImageView.swift */,
-                B3B469CF228F0F2600A68EDD /* ContouredButton.swift */,
-                B3B469D0228F0F2600A68EDD /* DropDownSearchField.swift */,
-            );
-            path = extra_view;
-            sourceTree = "<group>";
-        };
-        B3B469D1228F0F2600A68EDD /* Features */ = {
-            isa = PBXGroup;
-            children = (
-                DDD7D20725C1BCB70013BF0A /* Privacy */,
-                B3C0D4B023E0DB26002D984F /* Custom Dialogs */,
-                DD36717323B44A4B00D1ED67 /* More */,
-                B3B469D2228F0F2600A68EDD /* App Launch */,
-                B3B469D4228F0F2600A68EDD /* Security */,
-                B3B469E2228F0F2600A68EDD /* Wallet Setup */,
-                B3B469E9228F0F2600A68EDD /* Navigation Menu */,
-                B3B469EF228F0F2600A68EDD /* Overview */,
-                105836B523EACD390030FDF2 /* Receive */,
-                B3A3EF902295955100008A4E /* Send */,
-                100B122423E9EEAC005636A7 /* Transactions */,
-                B3B46A55228F0F7B00A68EDD /* TransactionDetails */,
-                B3C03B2123DD41BF00156D9F /* Wallets */,
-                10341DFF23CBBB700055DFDE /* Seed Backup */,
-            );
-            path = Features;
-            sourceTree = "<group>";
-        };
-        B3B469D2228F0F2600A68EDD /* App Launch */ = {
-            isa = PBXGroup;
-            children = (
-                B3B469D3228F0F2600A68EDD /* StartScreenViewController.swift */,
-            );
-            path = "App Launch";
-            sourceTree = "<group>";
-        };
-        B3B469D4228F0F2600A68EDD /* Security */ = {
-            isa = PBXGroup;
-            children = (
-                DD8F9D3B22BE7A5600FF8594 /* Security.storyboard */,
-                B3B469D6228F0F2600A68EDD /* SecurityViewController.swift */,
-                B3B469DC228F0F2600A68EDD /* SecurityCodeRequestBaseViewController.swift */,
-                B3B469D8228F0F2600A68EDD /* RequestPasswordViewController.swift */,
-                B3B469DA228F0F2600A68EDD /* RequestPinViewController.swift */,
-                B3B469DB228F0F2600A68EDD /* PinPasswordStrength.swift */,
-            );
-            path = Security;
-            sourceTree = "<group>";
-        };
-        B3B469E2228F0F2600A68EDD /* Wallet Setup */ = {
-            isa = PBXGroup;
-            children = (
-                DDA8154A243E56740011333F /* WalletSetup.storyboard */,
-                DD17D9CB23CE243D0017E41D /* RestoreExistingWalletViewController.swift */,
-                100B122D23E9EECB005636A7 /* RestoreExistingWalletSuccessViewController.swift */,
-            );
-            path = "Wallet Setup";
-            sourceTree = "<group>";
-        };
-        B3B469E9228F0F2600A68EDD /* Navigation Menu */ = {
-            isa = PBXGroup;
-            children = (
-                25E63F4D23312B2B009CD53E /* NavMenuFloatingButtons.swift */,
-                2557E1882355C6FA00B6A1B7 /* NavigationMenuTabBarController.swift */,
-                2557E18A2355C9F000B6A1B7 /* CustomTabMenuView.swift */,
-                10BA77982390059F00B67446 /* TabMenuItemView.swift */,
-                B3B469EC228F0F2600A68EDD /* MenuItem.swift */,
-            );
-            path = "Navigation Menu";
-            sourceTree = "<group>";
-        };
-        B3B469EF228F0F2600A68EDD /* Overview */ = {
-            isa = PBXGroup;
-            children = (
-                DDCF259922B8A346005FCBB9 /* Overview.storyboard */,
-                B3B469F1228F0F2600A68EDD /* OverviewViewController.swift */,
-                B34A2F9023E8ED1500B8BC01 /* MultiWalletSyncDetailsLoader.swift */,
-                B34A2F8E23E8E90500B8BC01 /* WalletSyncDetailsTableViewCell.swift */,
-                60778ADF26274DA9006B1FC2 /* WalletMixerCell.swift */,
-            );
-            path = Overview;
-            sourceTree = "<group>";
-        };
-        B3B469F3228F0F2600A68EDD /* Wallet Utils */ = {
-            isa = PBXGroup;
-            children = (
-                6007D38C24F42089000EC5CB /* PoliteiaNotification.swift */,
-                B3B469F6228F0F2600A68EDD /* WalletLoader.swift */,
-                25A4331B2373D0330018FFCF /* SyncManager.swift */,
-                B3B469F4228F0F2600A68EDD /* TransactionNotification.swift */,
-                B3C0D4AE23DF9C45002D984F /* Security.swift */,
-                B3B469F9228F0F2600A68EDD /* StartupPinOrPassword.swift */,
-                B3B469F7228F0F2600A68EDD /* SpendingPinOrPassword.swift */,
-                B3D21C9E2296E4F000609F23 /* ExchangeRates.swift */,
-                B379BA6423E2A2F1002CA92E /* SingleToMultiWalletMigration.swift */,
-            );
-            path = "Wallet Utils";
-            sourceTree = "<group>";
-        };
-        B3B46A3A228F0F6700A68EDD /* Resources */ = {
-            isa = PBXGroup;
-            children = (
-                B3B46A3B228F0F6700A68EDD /* bg-button@3x.png */,
-                B3B46A3C228F0F6700A68EDD /* bg-button.png */,
-                B3B46A3D228F0F6700A68EDD /* dcr-logo.png */,
-                B3B46A3E228F0F6700A68EDD /* progress bar-1s-200px.gif */,
-            );
-            path = Resources;
-            sourceTree = "<group>";
-        };
-        B3B46A48228F0F7B00A68EDD /* view_util */ = {
-            isa = PBXGroup;
-            children = (
-                B3B46A49228F0F7B00A68EDD /* DropMenuButton.swift */,
-                B3B46A4A228F0F7B00A68EDD /* Data.swift */,
-                B3B46A4B228F0F7B00A68EDD /* UIIMage.swift */,
-                B3B46A4C228F0F7B00A68EDD /* keyPadButton.swift */,
-                B3B46A4D228F0F7B00A68EDD /* customUImage.swift */,
-            );
-            path = view_util;
-            sourceTree = "<group>";
-        };
-        B3B46A55228F0F7B00A68EDD /* TransactionDetails */ = {
-            isa = PBXGroup;
-            children = (
-                B3B46ABB228F120700A68EDD /* Cells */,
-                B3B46A5F228F0F7B00A68EDD /* TransactionDetails.storyboard */,
-                B3B46A5E228F0F7B00A68EDD /* TransactionDetailsViewController.swift */,
-            );
-            path = TransactionDetails;
-            sourceTree = "<group>";
-        };
-        B3B46A73228F0F7C00A68EDD /* table_view_cell */ = {
-            isa = PBXGroup;
-            children = (
-                B3B46A75228F0F7C00A68EDD /* RecoveryWalletSeedWordCell.swift */,
-                B3B46A7A228F0F7C00A68EDD /* SeedCheckActiveCellView.swift */,
-                B3B46A7C228F0F7C00A68EDD /* ConfirmSeedViewCell.swift */,
-            );
-            path = table_view_cell;
-            sourceTree = "<group>";
-        };
-        B3B46ABB228F120700A68EDD /* Cells */ = {
-            isa = PBXGroup;
-            children = (
-                10945CD923F3DB0C00BBE242 /* TransactionOverviewCell.swift */,
-                102D724723ED5271002DCAF2 /* TransactionDetailCell.swift */,
-                10B7818023F066DA00AD2709 /* TransactionInputDetailCell.swift */,
-                10B7818423F0693C00AD2709 /* TransactionOutputDetailCell.swift */,
-            );
-            path = Cells;
-            sourceTree = "<group>";
-        };
-        B3C03B2123DD41BF00156D9F /* Wallets */ = {
-            isa = PBXGroup;
-            children = (
-                B3C03B2223DD41EE00156D9F /* Wallets.storyboard */,
-                B3E727CB23DD506E003B06B4 /* WalletsViewController.swift */,
-                B3E727C323DD4A5F003B06B4 /* WalletInfoTableViewCell.xib */,
-                B3E727C723DD4AD7003B06B4 /* WalletInfoTableViewCell.swift */,
-                DD493C01247654BC00C0D772 /* WatchOnlyWalletInfoTableViewCell.swift */,
-                DD493C05247654BC00C0D772 /* WatchOnlyWalletTableViewCell.xib */,
-                DD493BFF247654BC00C0D772 /* WatchOnlyWalletInfoTableViewCell.xib */,
-                DD493C03247654BC00C0D772 /* WatchOnlyWalletTableViewCell.swift */,
-                B3E727C523DD4ABF003B06B4 /* WalletAccountTableViewCell.xib */,
-                B3E727C923DD4AE7003B06B4 /* WalletAccountTableViewCell.swift */,
-                B3B9432823E4D0B30088EC3E /* WalletSettingsViewController.swift */,
-                B3D474DE23E55B5D00B6E305 /* WalletSettings.swift */,
-                B32EB42D23EEA24000E43D4F /* AccountDetailsViewController.swift */,
-            );
-            path = Wallets;
-            sourceTree = "<group>";
-        };
-        B3C0D4B023E0DB26002D984F /* Custom Dialogs */ = {
-            isa = PBXGroup;
-            children = (
-                B3C0D4B123E0DB56002D984F /* CustomDialogs.storyboard */,
-                B3C0D4B323E0DBF6002D984F /* SimpleTextInputDialog.swift */,
-                B3C0D4B523E0FBA5002D984F /* SimpleOkCancelDialog.swift */,
-                1034D5CE24113BF10009576C /* SimpleAlertDialog.swift */,
-                10C6610A23EC587B00754DED /* AccountSelectorDialog */,
-                B3D474E023E56CD900B6E305 /* CheckableListDialog */,
-                DD493BF7247327E800C0D772 /* MultipleTextInputDialog.swift */,
-            );
-            path = "Custom Dialogs";
-            sourceTree = "<group>";
-        };
-        B3D474E023E56CD900B6E305 /* CheckableListDialog */ = {
-            isa = PBXGroup;
-            children = (
-                B3D474E123E56CFD00B6E305 /* CheckableListDialogViewController.swift */,
-                B3D474E323E57DA200B6E305 /* CheckableListOptionTableViewCell.swift */,
-                B3A8E80923E593720094957B /* CheckableListOptionTableViewCell.xib */,
-            );
-            path = CheckableListDialog;
-            sourceTree = "<group>";
-        };
-        DD36717323B44A4B00D1ED67 /* More */ = {
-            isa = PBXGroup;
-            children = (
-                DD5AB14423BAE47A00863362 /* More Features */,
-                DDE2374523BA386C00C2A94F /* MoreMenuViewController.swift */,
-                DD36717623B44AB700D1ED67 /* More.storyboard */,
-                DD02AC6423969440004A73E3 /* MoreMenuItem.swift */,
-                DDE2374723BA386C00C2A94F /* MoreMenuItemCell.swift */,
-            );
-            path = More;
-            sourceTree = "<group>";
-        };
-        DD5AB14423BAE47A00863362 /* More Features */ = {
-            isa = PBXGroup;
-            children = (
-                60C7E54224ED88B8009E4569 /* Politeia */,
-                DDAD5023229F714600EDF91B /* Settings */,
-                B36255B322A11A9500C62946 /* Security Tools */,
-                DD5AB15123D6210B00863362 /* About */,
-                DD5AB15223D6212F00863362 /* Debug */,
-                DD5AB15323D6214B00863362 /* Help */,
-            );
-            path = "More Features";
-            sourceTree = "<group>";
-        };
-        DD5AB15123D6210B00863362 /* About */ = {
-            isa = PBXGroup;
-            children = (
-                DD5AB14523BAE47A00863362 /* About.storyboard */,
-                DDD65AD622A935460027CDA8 /* LicenseViewController.swift */,
-                DD5AB14B23D36F7E00863362 /* AboutTableViewController.swift */,
-            );
-            path = About;
-            sourceTree = "<group>";
-        };
-        DD5AB15223D6212F00863362 /* Debug */ = {
-            isa = PBXGroup;
-            children = (
-                DD5AB14723BAE47A00863362 /* Debug.storyboard */,
-                B3B46A66228F0F7B00A68EDD /* WalletLogViewController.swift */,
-                DD5AB14D23D4C12C00863362 /* DebugTableViewController.swift */,
-                DDA2F7CD24375FEF00A3DC7C /* StatisticsViewController.swift */,
-                60E8539F25B324C800E4CFDD /* ConnectedPeerViewcontroller.swift */,
-                60E853A725B48F9800E4CFDD /* ConnectedPeerTableViewCell.swift */,
-            );
-            path = Debug;
-            sourceTree = "<group>";
-        };
-        DD5AB15323D6214B00863362 /* Help */ = {
-            isa = PBXGroup;
-            children = (
-                DD5AB14923BAE47A00863362 /* Help.storyboard */,
-                DD5AB14F23D612C800863362 /* HelpTableViewController.swift */,
-            );
-            path = Help;
-            sourceTree = "<group>";
-        };
-        DD81CBC623B3A187009D3833 /* Validate Addresses */ = {
-            isa = PBXGroup;
-            children = (
-                DD81CBC723B3A219009D3833 /* ValidateAddresses.storyboard */,
-                DD81CBC923B3A298009D3833 /* ValidateAddressesViewController.swift */,
-            );
-            path = "Validate Addresses";
-            sourceTree = "<group>";
-        };
-        DDAD5023229F714600EDF91B /* Settings */ = {
-            isa = PBXGroup;
-            children = (
-                DDCF25A022B8A3D4005FCBB9 /* Settings.storyboard */,
-                B3B46A61228F0F7B00A68EDD /* SettingsController.swift */,
-                B3B46A62228F0F7B00A68EDD /* PeerSetTableViewController.swift */,
-                B3B46A6F228F0F7B00A68EDD /* CurrencyConversionOptionsViewController.swift */,
-            );
-            path = Settings;
-            sourceTree = "<group>";
-        };
-        DDD7D20725C1BCB70013BF0A /* Privacy */ = {
-            isa = PBXGroup;
-            children = (
-                DDD7D20825C1BCCB0013BF0A /* Privacy.storyboard */,
-                DD398AB725C35B03003BC77D /* PrivacySetupTypeViewController.swift */,
-                DDEEEE1725AB1B8E00794B67 /* PrivacySetupViewController.swift */,
-                DD569297259B9E3F004D4BE6 /* PrivacyViewController.swift */,
-                DD398ABA25C35B07003BC77D /* PrivacyManualSetupViewController.swift */,
-            );
-            path = Privacy;
-            sourceTree = "<group>";
-        };
-        DDB660F32486BABB0060B0C5 /* Decred WalletUITests */ = {
-            isa = PBXGroup;
-            children = (
-                DDB660F42486BABB0060B0C5 /* Decred_WalletUITests.swift */,
-                DDB660F62486BABB0060B0C5 /* Info.plist */,
-                DD2E176D24A95BAC001AF94D /* RestoreExistingWalletUITest.swift */,
-                DD2E177124A95CA4001AF94D /* SeedBackupUITest.swift */,
-            );
-            path = "Decred WalletUITests";
-            sourceTree = "<group>";
-        };
-        DDDF95C823C11F300057AA7F /* Verify Message */ = {
-            isa = PBXGroup;
-            children = (
-                DDDF95CB23C11F760057AA7F /* VerifyMessage.storyboard */,
-                DDDF95CD23C11F760057AA7F /* VerifyMessageViewController.swift */,
-            );
-            path = "Verify Message";
-            sourceTree = "<group>";
-        };
-        DDDF95D323C20AA70057AA7F /* Sign Message */ = {
-            isa = PBXGroup;
-            children = (
-                DDDF95D423C20AA70057AA7F /* SignMessage.storyboard */,
-                DDDF95D623C20AA70057AA7F /* SignMessageViewController.swift */,
-            );
-            path = "Sign Message";
-            sourceTree = "<group>";
-        };
+		100B122423E9EEAC005636A7 /* Transactions */ = {
+			isa = PBXGroup;
+			children = (
+				100B122723E9EEAC005636A7 /* Transactions.storyboard */,
+				100B122823E9EEAC005636A7 /* TransactionsViewController.swift */,
+				100B122523E9EEAC005636A7 /* TransactionTableViewCell.xib */,
+				100B122623E9EEAC005636A7 /* TransactionTableViewCell.swift */,
+				103BE67D240D1F9E007910DA /* WalletSelectorCollectionViewCell.swift */,
+			);
+			path = Transactions;
+			sourceTree = "<group>";
+		};
+		10341DFF23CBBB700055DFDE /* Seed Backup */ = {
+			isa = PBXGroup;
+			children = (
+				10341E0523CBBB700055DFDE /* SeedBackup.storyboard */,
+				10341E0623CBBB700055DFDE /* SeedBackupReminderViewController.swift */,
+				10341E0123CBBB700055DFDE /* SeedWordsDisplayViewController.swift */,
+				10341E0023CBBB700055DFDE /* SeedBackupSuccessViewController.swift */,
+				10341E0223CBBB700055DFDE /* SeedBackupVerifyViewController.swift */,
+				10341E0323CBBB700055DFDE /* SeedBackupVerifyTableViewCell.swift */,
+				10341E0423CBBB700055DFDE /* SeedWordsDisplayTableViewCell.swift */,
+			);
+			path = "Seed Backup";
+			sourceTree = "<group>";
+		};
+		105836B523EACD390030FDF2 /* Receive */ = {
+			isa = PBXGroup;
+			children = (
+				105836B723EACD390030FDF2 /* Receive.storyboard */,
+				105836B623EACD390030FDF2 /* ReceiveViewController.swift */,
+			);
+			path = Receive;
+			sourceTree = "<group>";
+		};
+		10C6610A23EC587B00754DED /* AccountSelectorDialog */ = {
+			isa = PBXGroup;
+			children = (
+				10C6610B23EC587B00754DED /* AccountSelectorDialog.swift */,
+				10C6610C23EC587B00754DED /* AccountSelectorTableViewCell.xib */,
+				10C6610D23EC587B00754DED /* AccountSelectorTableViewCell.swift */,
+			);
+			path = AccountSelectorDialog;
+			sourceTree = "<group>";
+		};
+		10D9FB9723C3956600CBF216 /* FloatingPlaceholderInputs */ = {
+			isa = PBXGroup;
+			children = (
+				10FABE4A23C72D6700BC201B /* FloatingPlaceholderInputProtocol.swift */,
+				10D9FB8E23C3956200CBF216 /* FloatingPlaceholderTextField.swift */,
+				10FABE4E23C7303E00BC201B /* FloatingPlaceholderTextView.swift */,
+				10D9FB9123C3956300CBF216 /* FloatingPlaceholderLabel.swift */,
+				10FABE5023C7307100BC201B /* FloatingPlaceholderBorderLayer.swift */,
+			);
+			path = FloatingPlaceholderInputs;
+			sourceTree = "<group>";
+		};
+		452B0148672C448C74CB5C1E /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				25751F522372C9460019F657 /* Dcrlibwallet.framework */,
+				A9714AB438E597D403032748 /* Pods_Decred_Wallet.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		60C7E54224ED88B8009E4569 /* Politeia */ = {
+			isa = PBXGroup;
+			children = (
+				60C7E54324ED88B8009E4569 /* Politeia.storyboard */,
+				60C7E54424ED88B8009E4569 /* PoliteiaTableViewCell.swift */,
+				60C7E54524ED88B8009E4569 /* PoliteiaController.swift */,
+				60DFF5D024F75D4500624161 /* PoliteiaDetailController.swift */,
+			);
+			path = Politeia;
+			sourceTree = "<group>";
+		};
+		8F7CDB697B0BC7D598AC1F98 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				6A0625AB1C6ACD2EC77F544F /* Pods-Decred Wallet.mainnet debug.xcconfig */,
+				B107091A1D996651AB5D8891 /* Pods-Decred Wallet.testnet debug.xcconfig */,
+				23F5A25CDDC0ADF47F98ED95 /* Pods-Decred Wallet.mainnet release.xcconfig */,
+				D59C7DB99807D17630259A55 /* Pods-Decred Wallet.testnet release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		B36255B322A11A9500C62946 /* Security Tools */ = {
+			isa = PBXGroup;
+			children = (
+				DDDF95D323C20AA70057AA7F /* Sign Message */,
+				DDDF95C823C11F300057AA7F /* Verify Message */,
+				DD81CBC623B3A187009D3833 /* Validate Addresses */,
+				DD89A04023B0842400C1ECE9 /* SecurityTools.storyboard */,
+				DD89A04223B08CF800C1ECE9 /* SecurityToolsViewController.swift */,
+				DD89A04423B08FDD00C1ECE9 /* SecurityToolsItem.swift */,
+				DD89A04623B091FF00C1ECE9 /* SecurityToolsItemCell.swift */,
+			);
+			path = "Security Tools";
+			sourceTree = "<group>";
+		};
+		B37AD09F240885DC00C83D80 /* WalletAccountView */ = {
+			isa = PBXGroup;
+			children = (
+				B37AD0A22408870B00C83D80 /* WalletAccountView.xib */,
+				B37AD0A424088A6700C83D80 /* WalletAccountView.swift */,
+			);
+			path = WalletAccountView;
+			sourceTree = "<group>";
+		};
+		B3A3EF8422936BEF00008A4E /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				B3A3EF8522936BFE00008A4E /* Reachability.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		B3A3EF8922937B7500008A4E /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				250D77BC23F2BF0F00CDC256 /* DecredAddressURI.swift */,
+				B304B39323F202A400B81798 /* Settings.swift */,
+				B3B46A4F228F0F7B00A68EDD /* Utils.swift */,
+				DD4948EB22C0E400006A35F8 /* LocalizedStrings.swift */,
+				AD24C23C2343E445009583C9 /* NotificationsManager.swift */,
+				DDAE90FF2435086B00FEC016 /* KeychainWrapper.swift */,
+				DDAE91012435092200FEC016 /* KeychainItemAccessibility.swift */,
+				DDAE91032435092200FEC016 /* ErrorMessageForLA.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
+		B3A3EF902295955100008A4E /* Send */ = {
+			isa = PBXGroup;
+			children = (
+				DDCF259B22B8A361005FCBB9 /* Send.storyboard */,
+				B3A3EF912295956300008A4E /* SendViewController.swift */,
+				B3B46A54228F0F7B00A68EDD /* ConfirmToSendFundViewController.swift */,
+			);
+			path = Send;
+			sourceTree = "<group>";
+		};
+		B3B46986228F0C2D00A68EDD = {
+			isa = PBXGroup;
+			children = (
+				B3B46991228F0C2E00A68EDD /* Decred Wallet */,
+				DDB660F32486BABB0060B0C5 /* Decred WalletUITests */,
+				B3B46990228F0C2D00A68EDD /* Products */,
+				8F7CDB697B0BC7D598AC1F98 /* Pods */,
+				452B0148672C448C74CB5C1E /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		B3B46990228F0C2D00A68EDD /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B3B4698F228F0C2D00A68EDD /* Decred Wallet.app */,
+				DDB660F22486BABB0060B0C5 /* Decred WalletUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		B3B46991228F0C2E00A68EDD /* Decred Wallet */ = {
+			isa = PBXGroup;
+			children = (
+				DD41737D22B1B31E00580935 /* Localizable.strings */,
+				B3A3EF8422936BEF00008A4E /* Network */,
+				B3B469BF228F0F2600A68EDD /* Constants */,
+				B3B469AC228F0F2600A68EDD /* Custom Views */,
+				B3B469C2228F0F2600A68EDD /* DcrlibwalletTypes */,
+				B3B469A7228F0F2600A68EDD /* Extensions */,
+				B3B469C6228F0F2600A68EDD /* extra_view */,
+				B3B469D1228F0F2600A68EDD /* Features */,
+				B3B469AF228F0F2600A68EDD /* Fonts */,
+				B3B46A3A228F0F6700A68EDD /* Resources */,
+				B3B46A73228F0F7C00A68EDD /* table_view_cell */,
+				B3B46A48228F0F7B00A68EDD /* view_util */,
+				B3B469F3228F0F2600A68EDD /* Wallet Utils */,
+				B3A3EF8922937B7500008A4E /* Utils */,
+				B3B46A7F228F0F7C00A68EDD /* Storyboard.swift */,
+				DDCF25A822B8A487005FCBB9 /* Main.storyboard */,
+				B3B46992228F0C2E00A68EDD /* AppDelegate.swift */,
+				B3B46999228F0C2E00A68EDD /* Assets.xcassets */,
+				DD53FD762459F8B3003CA279 /* beep.mp3 */,
+				B3B4699B228F0C2E00A68EDD /* LaunchScreen.storyboard */,
+				B3B4699E228F0C2E00A68EDD /* Info.plist */,
+				B39BDC4C228F798300F3FB55 /* BuildConfig.swift */,
+			);
+			path = "Decred Wallet";
+			sourceTree = "<group>";
+		};
+		B3B469A7228F0F2600A68EDD /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				DD3DF86522C3F0BD00E168AB /* UILabel.swift */,
+				B3B469F8228F0F2600A68EDD /* Dcrlibwallet.swift */,
+				B3B469A8228F0F2600A68EDD /* UIColor.swift */,
+				B3B469A9228F0F2600A68EDD /* Extensions.swift */,
+				B3B469AA228F0F2600A68EDD /* String.swift */,
+				B3B469AB228F0F2600A68EDD /* UIViewController.swift */,
+				B3A3EF87229375D100008A4E /* Date.swift */,
+				B36EFD352298617C002753B2 /* UIButton.swift */,
+				B3967B3C22A75BD400E14432 /* UITableView.swift */,
+				B3B469C7228F0F2600A68EDD /* UIView.swift */,
+				DDA8734D245F69C00029A13D /* CIImage.swift */,
+				60C7E54024ED8738009E4569 /* PlainHorizontalProgressBar.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		B3B469AC228F0F2600A68EDD /* Custom Views */ = {
+			isa = PBXGroup;
+			children = (
+				B37AD09F240885DC00C83D80 /* WalletAccountView */,
+				10D9FB9723C3956600CBF216 /* FloatingPlaceholderInputs */,
+				B3B469AD228F0F2600A68EDD /* Button.swift */,
+				10341E0E23CBBB7E0055DFDE /* Label.swift */,
+				108A2E7323DE311900B13A22 /* SelfSizedTableView.swift */,
+				B3635B81229FE5870052EB4D /* QRImageScanner.swift */,
+				102AFAC323AA2B4D007E2EBD /* ProgressView.swift */,
+				B3456D2423D91CF600B04860 /* RoundedView.swift */,
+				DD81CBC223B39DF1009D3833 /* FloatingLabelTextInput.swift */,
+				DD81CBC423B39E6A009D3833 /* PaddedLabel.swift */,
+				C8BBC3AD2450CE1E001A5A9E /* SuffixTextField.swift */,
+				DD67443725CA321C001AD0B5 /* ToolTipView.swift */,
+				6004FFB725CC5D0100D5A25C /* LoadingView.swift */,
+			);
+			path = "Custom Views";
+			sourceTree = "<group>";
+		};
+		B3B469AF228F0F2600A68EDD /* Fonts */ = {
+			isa = PBXGroup;
+			children = (
+				B3B469B5228F0F2600A68EDD /* SourceSansPro-Regular.ttf */,
+				B3B469BC228F0F2600A68EDD /* SourceSansPro-SemiBold.ttf */,
+				B3B469B0228F0F2600A68EDD /* Inconsolata */,
+				B3B469B2228F0F2600A68EDD /* Source_Sans_Pro */,
+			);
+			path = Fonts;
+			sourceTree = "<group>";
+		};
+		B3B469B0228F0F2600A68EDD /* Inconsolata */ = {
+			isa = PBXGroup;
+			children = (
+				B3B469B1228F0F2600A68EDD /* inconsolata_regular.ttf */,
+			);
+			path = Inconsolata;
+			sourceTree = "<group>";
+		};
+		B3B469B2228F0F2600A68EDD /* Source_Sans_Pro */ = {
+			isa = PBXGroup;
+			children = (
+				B3B469B3228F0F2600A68EDD /* SourceSansPro-BlackItalic.ttf */,
+				B3B469B4228F0F2600A68EDD /* SourceSansPro-SemiBoldItalic.ttf */,
+				B3B469B6228F0F2600A68EDD /* SourceSansPro-Bold.ttf */,
+				B3B469B7228F0F2600A68EDD /* SourceSansPro-LightItalic.ttf */,
+				B3B469B8228F0F2600A68EDD /* SourceSansPro-Light.ttf */,
+				B3B469B9228F0F2600A68EDD /* SourceSansPro-Black.ttf */,
+				B3B469BA228F0F2600A68EDD /* SourceSansPro-ExtraLight.ttf */,
+				B3B469BB228F0F2600A68EDD /* SourceSansPro-BoldItalic.ttf */,
+				B3B469BD228F0F2600A68EDD /* SourceSansPro-ExtraLightItalic.ttf */,
+				B3B469BE228F0F2600A68EDD /* SourceSansPro-Italic.ttf */,
+			);
+			path = Source_Sans_Pro;
+			sourceTree = "<group>";
+		};
+		B3B469BF228F0F2600A68EDD /* Constants */ = {
+			isa = PBXGroup;
+			children = (
+				B3B469C0228F0F2600A68EDD /* Constants.swift */,
+				B3B469C1228F0F2600A68EDD /* wordlist.txt */,
+			);
+			path = Constants;
+			sourceTree = "<group>";
+		};
+		B3B469C2228F0F2600A68EDD /* DcrlibwalletTypes */ = {
+			isa = PBXGroup;
+			children = (
+				B35C55D7232FED610006A765 /* Transaction.swift */,
+				60C7E54A24ED88F0009E4569 /* Politeia.swift */,
+				60C7E54924ED88F0009E4569 /* PoliteiaStatus.swift */,
+				B3E727CD23DE0FCC003B06B4 /* Wallet.swift */,
+				6007D38A24F406AA000EC5CB /* Response.swift */,
+				60E853A325B4805200E4CFDD /* PeerInfo.swift */,
+			);
+			path = DcrlibwalletTypes;
+			sourceTree = "<group>";
+		};
+		B3B469C6228F0F2600A68EDD /* extra_view */ = {
+			isa = PBXGroup;
+			children = (
+				B3B469C8228F0F2600A68EDD /* UITableViewExtension.swift */,
+				B3B469C9228F0F2600A68EDD /* TextFieldDoneButton.swift */,
+				B3B469CD228F0F2600A68EDD /* UIImageView.swift */,
+				B3B469CF228F0F2600A68EDD /* ContouredButton.swift */,
+				B3B469D0228F0F2600A68EDD /* DropDownSearchField.swift */,
+			);
+			path = extra_view;
+			sourceTree = "<group>";
+		};
+		B3B469D1228F0F2600A68EDD /* Features */ = {
+			isa = PBXGroup;
+			children = (
+				DDD7D20725C1BCB70013BF0A /* Privacy */,
+				B3C0D4B023E0DB26002D984F /* Custom Dialogs */,
+				DD36717323B44A4B00D1ED67 /* More */,
+				B3B469D2228F0F2600A68EDD /* App Launch */,
+				B3B469D4228F0F2600A68EDD /* Security */,
+				B3B469E2228F0F2600A68EDD /* Wallet Setup */,
+				B3B469E9228F0F2600A68EDD /* Navigation Menu */,
+				B3B469EF228F0F2600A68EDD /* Overview */,
+				105836B523EACD390030FDF2 /* Receive */,
+				B3A3EF902295955100008A4E /* Send */,
+				100B122423E9EEAC005636A7 /* Transactions */,
+				B3B46A55228F0F7B00A68EDD /* TransactionDetails */,
+				B3C03B2123DD41BF00156D9F /* Wallets */,
+				10341DFF23CBBB700055DFDE /* Seed Backup */,
+			);
+			path = Features;
+			sourceTree = "<group>";
+		};
+		B3B469D2228F0F2600A68EDD /* App Launch */ = {
+			isa = PBXGroup;
+			children = (
+				B3B469D3228F0F2600A68EDD /* StartScreenViewController.swift */,
+			);
+			path = "App Launch";
+			sourceTree = "<group>";
+		};
+		B3B469D4228F0F2600A68EDD /* Security */ = {
+			isa = PBXGroup;
+			children = (
+				DD8F9D3B22BE7A5600FF8594 /* Security.storyboard */,
+				B3B469D6228F0F2600A68EDD /* SecurityViewController.swift */,
+				B3B469DC228F0F2600A68EDD /* SecurityCodeRequestBaseViewController.swift */,
+				B3B469D8228F0F2600A68EDD /* RequestPasswordViewController.swift */,
+				B3B469DA228F0F2600A68EDD /* RequestPinViewController.swift */,
+				B3B469DB228F0F2600A68EDD /* PinPasswordStrength.swift */,
+			);
+			path = Security;
+			sourceTree = "<group>";
+		};
+		B3B469E2228F0F2600A68EDD /* Wallet Setup */ = {
+			isa = PBXGroup;
+			children = (
+				DDA8154A243E56740011333F /* WalletSetup.storyboard */,
+				DD17D9CB23CE243D0017E41D /* RestoreExistingWalletViewController.swift */,
+				100B122D23E9EECB005636A7 /* RestoreExistingWalletSuccessViewController.swift */,
+			);
+			path = "Wallet Setup";
+			sourceTree = "<group>";
+		};
+		B3B469E9228F0F2600A68EDD /* Navigation Menu */ = {
+			isa = PBXGroup;
+			children = (
+				25E63F4D23312B2B009CD53E /* NavMenuFloatingButtons.swift */,
+				2557E1882355C6FA00B6A1B7 /* NavigationMenuTabBarController.swift */,
+				2557E18A2355C9F000B6A1B7 /* CustomTabMenuView.swift */,
+				10BA77982390059F00B67446 /* TabMenuItemView.swift */,
+				B3B469EC228F0F2600A68EDD /* MenuItem.swift */,
+			);
+			path = "Navigation Menu";
+			sourceTree = "<group>";
+		};
+		B3B469EF228F0F2600A68EDD /* Overview */ = {
+			isa = PBXGroup;
+			children = (
+				DDCF259922B8A346005FCBB9 /* Overview.storyboard */,
+				B3B469F1228F0F2600A68EDD /* OverviewViewController.swift */,
+				B34A2F9023E8ED1500B8BC01 /* MultiWalletSyncDetailsLoader.swift */,
+				B34A2F8E23E8E90500B8BC01 /* WalletSyncDetailsTableViewCell.swift */,
+				60778ADF26274DA9006B1FC2 /* WalletMixerCell.swift */,
+			);
+			path = Overview;
+			sourceTree = "<group>";
+		};
+		B3B469F3228F0F2600A68EDD /* Wallet Utils */ = {
+			isa = PBXGroup;
+			children = (
+				6007D38C24F42089000EC5CB /* PoliteiaNotification.swift */,
+				B3B469F6228F0F2600A68EDD /* WalletLoader.swift */,
+				25A4331B2373D0330018FFCF /* SyncManager.swift */,
+				B3B469F4228F0F2600A68EDD /* TransactionNotification.swift */,
+				B3C0D4AE23DF9C45002D984F /* Security.swift */,
+				B3B469F9228F0F2600A68EDD /* StartupPinOrPassword.swift */,
+				B3B469F7228F0F2600A68EDD /* SpendingPinOrPassword.swift */,
+				B3D21C9E2296E4F000609F23 /* ExchangeRates.swift */,
+				B379BA6423E2A2F1002CA92E /* SingleToMultiWalletMigration.swift */,
+			);
+			path = "Wallet Utils";
+			sourceTree = "<group>";
+		};
+		B3B46A3A228F0F6700A68EDD /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				B3B46A3B228F0F6700A68EDD /* bg-button@3x.png */,
+				B3B46A3C228F0F6700A68EDD /* bg-button.png */,
+				B3B46A3D228F0F6700A68EDD /* dcr-logo.png */,
+				B3B46A3E228F0F6700A68EDD /* progress bar-1s-200px.gif */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		B3B46A48228F0F7B00A68EDD /* view_util */ = {
+			isa = PBXGroup;
+			children = (
+				B3B46A49228F0F7B00A68EDD /* DropMenuButton.swift */,
+				B3B46A4A228F0F7B00A68EDD /* Data.swift */,
+				B3B46A4B228F0F7B00A68EDD /* UIIMage.swift */,
+				B3B46A4C228F0F7B00A68EDD /* keyPadButton.swift */,
+				B3B46A4D228F0F7B00A68EDD /* customUImage.swift */,
+			);
+			path = view_util;
+			sourceTree = "<group>";
+		};
+		B3B46A55228F0F7B00A68EDD /* TransactionDetails */ = {
+			isa = PBXGroup;
+			children = (
+				B3B46ABB228F120700A68EDD /* Cells */,
+				B3B46A5F228F0F7B00A68EDD /* TransactionDetails.storyboard */,
+				B3B46A5E228F0F7B00A68EDD /* TransactionDetailsViewController.swift */,
+			);
+			path = TransactionDetails;
+			sourceTree = "<group>";
+		};
+		B3B46A73228F0F7C00A68EDD /* table_view_cell */ = {
+			isa = PBXGroup;
+			children = (
+				B3B46A75228F0F7C00A68EDD /* RecoveryWalletSeedWordCell.swift */,
+				B3B46A7A228F0F7C00A68EDD /* SeedCheckActiveCellView.swift */,
+				B3B46A7C228F0F7C00A68EDD /* ConfirmSeedViewCell.swift */,
+			);
+			path = table_view_cell;
+			sourceTree = "<group>";
+		};
+		B3B46ABB228F120700A68EDD /* Cells */ = {
+			isa = PBXGroup;
+			children = (
+				10945CD923F3DB0C00BBE242 /* TransactionOverviewCell.swift */,
+				102D724723ED5271002DCAF2 /* TransactionDetailCell.swift */,
+				10B7818023F066DA00AD2709 /* TransactionInputDetailCell.swift */,
+				10B7818423F0693C00AD2709 /* TransactionOutputDetailCell.swift */,
+			);
+			path = Cells;
+			sourceTree = "<group>";
+		};
+		B3C03B2123DD41BF00156D9F /* Wallets */ = {
+			isa = PBXGroup;
+			children = (
+				B3C03B2223DD41EE00156D9F /* Wallets.storyboard */,
+				B3E727CB23DD506E003B06B4 /* WalletsViewController.swift */,
+				B3E727C323DD4A5F003B06B4 /* WalletInfoTableViewCell.xib */,
+				B3E727C723DD4AD7003B06B4 /* WalletInfoTableViewCell.swift */,
+				DD493C01247654BC00C0D772 /* WatchOnlyWalletInfoTableViewCell.swift */,
+				DD493C05247654BC00C0D772 /* WatchOnlyWalletTableViewCell.xib */,
+				DD493BFF247654BC00C0D772 /* WatchOnlyWalletInfoTableViewCell.xib */,
+				DD493C03247654BC00C0D772 /* WatchOnlyWalletTableViewCell.swift */,
+				B3E727C523DD4ABF003B06B4 /* WalletAccountTableViewCell.xib */,
+				B3E727C923DD4AE7003B06B4 /* WalletAccountTableViewCell.swift */,
+				B3B9432823E4D0B30088EC3E /* WalletSettingsViewController.swift */,
+				B3D474DE23E55B5D00B6E305 /* WalletSettings.swift */,
+				B32EB42D23EEA24000E43D4F /* AccountDetailsViewController.swift */,
+			);
+			path = Wallets;
+			sourceTree = "<group>";
+		};
+		B3C0D4B023E0DB26002D984F /* Custom Dialogs */ = {
+			isa = PBXGroup;
+			children = (
+				B3C0D4B123E0DB56002D984F /* CustomDialogs.storyboard */,
+				B3C0D4B323E0DBF6002D984F /* SimpleTextInputDialog.swift */,
+				B3C0D4B523E0FBA5002D984F /* SimpleOkCancelDialog.swift */,
+				1034D5CE24113BF10009576C /* SimpleAlertDialog.swift */,
+				10C6610A23EC587B00754DED /* AccountSelectorDialog */,
+				B3D474E023E56CD900B6E305 /* CheckableListDialog */,
+				DD493BF7247327E800C0D772 /* MultipleTextInputDialog.swift */,
+			);
+			path = "Custom Dialogs";
+			sourceTree = "<group>";
+		};
+		B3D474E023E56CD900B6E305 /* CheckableListDialog */ = {
+			isa = PBXGroup;
+			children = (
+				B3D474E123E56CFD00B6E305 /* CheckableListDialogViewController.swift */,
+				B3D474E323E57DA200B6E305 /* CheckableListOptionTableViewCell.swift */,
+				B3A8E80923E593720094957B /* CheckableListOptionTableViewCell.xib */,
+			);
+			path = CheckableListDialog;
+			sourceTree = "<group>";
+		};
+		DD36717323B44A4B00D1ED67 /* More */ = {
+			isa = PBXGroup;
+			children = (
+				DD5AB14423BAE47A00863362 /* More Features */,
+				DDE2374523BA386C00C2A94F /* MoreMenuViewController.swift */,
+				DD36717623B44AB700D1ED67 /* More.storyboard */,
+				DD02AC6423969440004A73E3 /* MoreMenuItem.swift */,
+				DDE2374723BA386C00C2A94F /* MoreMenuItemCell.swift */,
+			);
+			path = More;
+			sourceTree = "<group>";
+		};
+		DD5AB14423BAE47A00863362 /* More Features */ = {
+			isa = PBXGroup;
+			children = (
+				60C7E54224ED88B8009E4569 /* Politeia */,
+				DDAD5023229F714600EDF91B /* Settings */,
+				B36255B322A11A9500C62946 /* Security Tools */,
+				DD5AB15123D6210B00863362 /* About */,
+				DD5AB15223D6212F00863362 /* Debug */,
+				DD5AB15323D6214B00863362 /* Help */,
+			);
+			path = "More Features";
+			sourceTree = "<group>";
+		};
+		DD5AB15123D6210B00863362 /* About */ = {
+			isa = PBXGroup;
+			children = (
+				DD5AB14523BAE47A00863362 /* About.storyboard */,
+				DDD65AD622A935460027CDA8 /* LicenseViewController.swift */,
+				DD5AB14B23D36F7E00863362 /* AboutTableViewController.swift */,
+			);
+			path = About;
+			sourceTree = "<group>";
+		};
+		DD5AB15223D6212F00863362 /* Debug */ = {
+			isa = PBXGroup;
+			children = (
+				DD5AB14723BAE47A00863362 /* Debug.storyboard */,
+				B3B46A66228F0F7B00A68EDD /* WalletLogViewController.swift */,
+				DD5AB14D23D4C12C00863362 /* DebugTableViewController.swift */,
+				DDA2F7CD24375FEF00A3DC7C /* StatisticsViewController.swift */,
+				60E8539F25B324C800E4CFDD /* ConnectedPeerViewcontroller.swift */,
+				60E853A725B48F9800E4CFDD /* ConnectedPeerTableViewCell.swift */,
+			);
+			path = Debug;
+			sourceTree = "<group>";
+		};
+		DD5AB15323D6214B00863362 /* Help */ = {
+			isa = PBXGroup;
+			children = (
+				DD5AB14923BAE47A00863362 /* Help.storyboard */,
+				DD5AB14F23D612C800863362 /* HelpTableViewController.swift */,
+			);
+			path = Help;
+			sourceTree = "<group>";
+		};
+		DD81CBC623B3A187009D3833 /* Validate Addresses */ = {
+			isa = PBXGroup;
+			children = (
+				DD81CBC723B3A219009D3833 /* ValidateAddresses.storyboard */,
+				DD81CBC923B3A298009D3833 /* ValidateAddressesViewController.swift */,
+			);
+			path = "Validate Addresses";
+			sourceTree = "<group>";
+		};
+		DDAD5023229F714600EDF91B /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				DDCF25A022B8A3D4005FCBB9 /* Settings.storyboard */,
+				B3B46A61228F0F7B00A68EDD /* SettingsController.swift */,
+				B3B46A62228F0F7B00A68EDD /* PeerSetTableViewController.swift */,
+				B3B46A6F228F0F7B00A68EDD /* CurrencyConversionOptionsViewController.swift */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
+		DDB660F32486BABB0060B0C5 /* Decred WalletUITests */ = {
+			isa = PBXGroup;
+			children = (
+				DDB660F42486BABB0060B0C5 /* Decred_WalletUITests.swift */,
+				DDB660F62486BABB0060B0C5 /* Info.plist */,
+				DD2E176D24A95BAC001AF94D /* RestoreExistingWalletUITest.swift */,
+				DD2E177124A95CA4001AF94D /* SeedBackupUITest.swift */,
+			);
+			path = "Decred WalletUITests";
+			sourceTree = "<group>";
+		};
+		DDD7D20725C1BCB70013BF0A /* Privacy */ = {
+			isa = PBXGroup;
+			children = (
+				DDD7D20825C1BCCB0013BF0A /* Privacy.storyboard */,
+				DD398AB725C35B03003BC77D /* PrivacySetupTypeViewController.swift */,
+				DDEEEE1725AB1B8E00794B67 /* PrivacySetupViewController.swift */,
+				DD569297259B9E3F004D4BE6 /* PrivacyViewController.swift */,
+				DD398ABA25C35B07003BC77D /* PrivacyManualSetupViewController.swift */,
+			);
+			path = Privacy;
+			sourceTree = "<group>";
+		};
+		DDDF95C823C11F300057AA7F /* Verify Message */ = {
+			isa = PBXGroup;
+			children = (
+				DDDF95CB23C11F760057AA7F /* VerifyMessage.storyboard */,
+				DDDF95CD23C11F760057AA7F /* VerifyMessageViewController.swift */,
+			);
+			path = "Verify Message";
+			sourceTree = "<group>";
+		};
+		DDDF95D323C20AA70057AA7F /* Sign Message */ = {
+			isa = PBXGroup;
+			children = (
+				DDDF95D423C20AA70057AA7F /* SignMessage.storyboard */,
+				DDDF95D623C20AA70057AA7F /* SignMessageViewController.swift */,
+			);
+			path = "Sign Message";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-        B3B4698E228F0C2D00A68EDD /* Decred Wallet */ = {
-            isa = PBXNativeTarget;
-            buildConfigurationList = B3B469A1228F0C2E00A68EDD /* Build configuration list for PBXNativeTarget "Decred Wallet" */;
-            buildPhases = (
-                4A4B0268771D325AB934983F /* [CP] Check Pods Manifest.lock */,
-                B3B4698B228F0C2D00A68EDD /* Sources */,
-                B3B4698C228F0C2D00A68EDD /* Frameworks */,
-                B3B4698D228F0C2D00A68EDD /* Resources */,
-                CF3A355769146908EB9B8041 /* [CP] Embed Pods Frameworks */,
-            );
-            buildRules = (
-            );
-            dependencies = (
-            );
-            name = "Decred Wallet";
-            productName = decred_wallet;
-            productReference = B3B4698F228F0C2D00A68EDD /* Decred Wallet.app */;
-            productType = "com.apple.product-type.application";
-        };
-        DDB660F12486BABB0060B0C5 /* Decred WalletUITests */ = {
-            isa = PBXNativeTarget;
-            buildConfigurationList = DDB660FD2486BABB0060B0C5 /* Build configuration list for PBXNativeTarget "Decred WalletUITests" */;
-            buildPhases = (
-                DDB660EE2486BABB0060B0C5 /* Sources */,
-                DDB660EF2486BABB0060B0C5 /* Frameworks */,
-                DDB660F02486BABB0060B0C5 /* Resources */,
-            );
-            buildRules = (
-            );
-            dependencies = (
-                DDB660F82486BABB0060B0C5 /* PBXTargetDependency */,
-            );
-            name = "Decred WalletUITests";
-            productName = "Decred WalletUITests";
-            productReference = DDB660F22486BABB0060B0C5 /* Decred WalletUITests.xctest */;
-            productType = "com.apple.product-type.bundle.ui-testing";
-        };
+		B3B4698E228F0C2D00A68EDD /* Decred Wallet */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B3B469A1228F0C2E00A68EDD /* Build configuration list for PBXNativeTarget "Decred Wallet" */;
+			buildPhases = (
+				4A4B0268771D325AB934983F /* [CP] Check Pods Manifest.lock */,
+				B3B4698B228F0C2D00A68EDD /* Sources */,
+				B3B4698C228F0C2D00A68EDD /* Frameworks */,
+				B3B4698D228F0C2D00A68EDD /* Resources */,
+				CF3A355769146908EB9B8041 /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Decred Wallet";
+			productName = decred_wallet;
+			productReference = B3B4698F228F0C2D00A68EDD /* Decred Wallet.app */;
+			productType = "com.apple.product-type.application";
+		};
+		DDB660F12486BABB0060B0C5 /* Decred WalletUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DDB660FD2486BABB0060B0C5 /* Build configuration list for PBXNativeTarget "Decred WalletUITests" */;
+			buildPhases = (
+				DDB660EE2486BABB0060B0C5 /* Sources */,
+				DDB660EF2486BABB0060B0C5 /* Frameworks */,
+				DDB660F02486BABB0060B0C5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DDB660F82486BABB0060B0C5 /* PBXTargetDependency */,
+			);
+			name = "Decred WalletUITests";
+			productName = "Decred WalletUITests";
+			productReference = DDB660F22486BABB0060B0C5 /* Decred WalletUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-        B3B46987228F0C2D00A68EDD /* Project object */ = {
-            isa = PBXProject;
-            attributes = {
-                LastSwiftUpdateCheck = 1140;
-                LastUpgradeCheck = 1220;
-                ORGANIZATIONNAME = Decred;
-                TargetAttributes = {
-                    B3B4698E228F0C2D00A68EDD = {
-                        CreatedOnToolsVersion = 10.2.1;
-                    };
-                    DDB660F12486BABB0060B0C5 = {
-                        CreatedOnToolsVersion = 11.4.1;
-                        TestTargetID = B3B4698E228F0C2D00A68EDD;
-                    };
-                };
-            };
-            buildConfigurationList = B3B4698A228F0C2D00A68EDD /* Build configuration list for PBXProject "Decred Wallet" */;
-            compatibilityVersion = "Xcode 9.3";
-            developmentRegion = en;
-            hasScannedForEncodings = 0;
-            knownRegions = (
-                en,
-                Base,
-                "ru-RU",
-                "zh-Hans",
-                es,
-                vi,
-                "pt-BR",
-                pl,
-                fr,
-            );
-            mainGroup = B3B46986228F0C2D00A68EDD;
-            productRefGroup = B3B46990228F0C2D00A68EDD /* Products */;
-            projectDirPath = "";
-            projectRoot = "";
-            targets = (
-                B3B4698E228F0C2D00A68EDD /* Decred Wallet */,
-                DDB660F12486BABB0060B0C5 /* Decred WalletUITests */,
-            );
-        };
+		B3B46987228F0C2D00A68EDD /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1140;
+				LastUpgradeCheck = 1250;
+				ORGANIZATIONNAME = Decred;
+				TargetAttributes = {
+					B3B4698E228F0C2D00A68EDD = {
+						CreatedOnToolsVersion = 10.2.1;
+					};
+					DDB660F12486BABB0060B0C5 = {
+						CreatedOnToolsVersion = 11.4.1;
+						TestTargetID = B3B4698E228F0C2D00A68EDD;
+					};
+				};
+			};
+			buildConfigurationList = B3B4698A228F0C2D00A68EDD /* Build configuration list for PBXProject "Decred Wallet" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+				"ru-RU",
+				"zh-Hans",
+				es,
+				vi,
+				"pt-BR",
+				pl,
+				fr,
+			);
+			mainGroup = B3B46986228F0C2D00A68EDD;
+			productRefGroup = B3B46990228F0C2D00A68EDD /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				B3B4698E228F0C2D00A68EDD /* Decred Wallet */,
+				DDB660F12486BABB0060B0C5 /* Decred WalletUITests */,
+			);
+		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-        B3B4698D228F0C2D00A68EDD /* Resources */ = {
-            isa = PBXResourcesBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-                DD53FD772459F8B3003CA279 /* beep.mp3 in Resources */,
-                B3C0D4B223E0DB56002D984F /* CustomDialogs.storyboard in Resources */,
-                B3B46A41228F0F6700A68EDD /* dcr-logo.png in Resources */,
-                105836B923EACD390030FDF2 /* Receive.storyboard in Resources */,
-                B3B46A02228F0F2700A68EDD /* SourceSansPro-SemiBoldItalic.ttf in Resources */,
-                100B122B23E9EEAC005636A7 /* Transactions.storyboard in Resources */,
-                B3B46A0C228F0F2700A68EDD /* SourceSansPro-Italic.ttf in Resources */,
-                B3B46A40228F0F6700A68EDD /* bg-button.png in Resources */,
-                B3B46A3F228F0F6700A68EDD /* bg-button@3x.png in Resources */,
-                B3B46A01228F0F2700A68EDD /* SourceSansPro-BlackItalic.ttf in Resources */,
-                B3B46A06228F0F2700A68EDD /* SourceSansPro-Light.ttf in Resources */,
-                B3B46A04228F0F2700A68EDD /* SourceSansPro-Bold.ttf in Resources */,
-                B3E727C423DD4A5F003B06B4 /* WalletInfoTableViewCell.xib in Resources */,
-                B3B46A0B228F0F2700A68EDD /* SourceSansPro-ExtraLightItalic.ttf in Resources */,
-                B3B46A07228F0F2700A68EDD /* SourceSansPro-Black.ttf in Resources */,
-                DD81CBC823B3A219009D3833 /* ValidateAddresses.storyboard in Resources */,
-                B3B4699D228F0C2E00A68EDD /* LaunchScreen.storyboard in Resources */,
-                DDDF95CC23C11F760057AA7F /* VerifyMessage.storyboard in Resources */,
-                DD493C00247654BC00C0D772 /* WatchOnlyWalletInfoTableViewCell.xib in Resources */,
-                DDCF25A922B8A488005FCBB9 /* Main.storyboard in Resources */,
-                DDCF259C22B8A362005FCBB9 /* Send.storyboard in Resources */,
-                10341E0C23CBBB700055DFDE /* SeedBackup.storyboard in Resources */,
-                DD36717723B44AB700D1ED67 /* More.storyboard in Resources */,
-                DD89A04123B0842400C1ECE9 /* SecurityTools.storyboard in Resources */,
-                DDCF259A22B8A347005FCBB9 /* Overview.storyboard in Resources */,
-                DD8F9D3C22BE7A5600FF8594 /* Security.storyboard in Resources */,
-                B3B46A03228F0F2700A68EDD /* SourceSansPro-Regular.ttf in Resources */,
-                B3B46A09228F0F2700A68EDD /* SourceSansPro-BoldItalic.ttf in Resources */,
-                B3C03B2323DD41EE00156D9F /* Wallets.storyboard in Resources */,
-                10C6610F23EC587B00754DED /* AccountSelectorTableViewCell.xib in Resources */,
-                DD5AB14A23BAE47A00863362 /* Help.storyboard in Resources */,
-                B3B46A98228F0F7D00A68EDD /* TransactionDetails.storyboard in Resources */,
-                DD5AB14623BAE47A00863362 /* About.storyboard in Resources */,
-                DDCF25A122B8A3D4005FCBB9 /* Settings.storyboard in Resources */,
-                DD5AB14823BAE47A00863362 /* Debug.storyboard in Resources */,
-                B3B46A05228F0F2700A68EDD /* SourceSansPro-LightItalic.ttf in Resources */,
-                100B122923E9EEAC005636A7 /* TransactionTableViewCell.xib in Resources */,
-                B37AD0A32408870B00C83D80 /* WalletAccountView.xib in Resources */,
-                DDA8154B243E56750011333F /* WalletSetup.storyboard in Resources */,
-                B3B46A08228F0F2700A68EDD /* SourceSansPro-ExtraLight.ttf in Resources */,
-                B3B46A00228F0F2700A68EDD /* inconsolata_regular.ttf in Resources */,
-                DD41737B22B1B31E00580935 /* Localizable.strings in Resources */,
-                B3B4699A228F0C2E00A68EDD /* Assets.xcassets in Resources */,
-                B3B46A0A228F0F2700A68EDD /* SourceSansPro-SemiBold.ttf in Resources */,
-                B3B46A42228F0F6700A68EDD /* progress bar-1s-200px.gif in Resources */,
-                B3B46A0E228F0F2700A68EDD /* wordlist.txt in Resources */,
-                B3E727C623DD4ABF003B06B4 /* WalletAccountTableViewCell.xib in Resources */,
-                DDD7D20925C1BCCB0013BF0A /* Privacy.storyboard in Resources */,
-                B3A8E80A23E593720094957B /* CheckableListOptionTableViewCell.xib in Resources */,
-                DDDF95D523C20AA70057AA7F /* SignMessage.storyboard in Resources */,
-                DD493C06247654BC00C0D772 /* WatchOnlyWalletTableViewCell.xib in Resources */,
-                60C7E54624ED88B8009E4569 /* Politeia.storyboard in Resources */,
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-        };
-        DDB660F02486BABB0060B0C5 /* Resources */ = {
-            isa = PBXResourcesBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-        };
+		B3B4698D228F0C2D00A68EDD /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DD53FD772459F8B3003CA279 /* beep.mp3 in Resources */,
+				B3C0D4B223E0DB56002D984F /* CustomDialogs.storyboard in Resources */,
+				B3B46A41228F0F6700A68EDD /* dcr-logo.png in Resources */,
+				105836B923EACD390030FDF2 /* Receive.storyboard in Resources */,
+				B3B46A02228F0F2700A68EDD /* SourceSansPro-SemiBoldItalic.ttf in Resources */,
+				100B122B23E9EEAC005636A7 /* Transactions.storyboard in Resources */,
+				B3B46A0C228F0F2700A68EDD /* SourceSansPro-Italic.ttf in Resources */,
+				B3B46A40228F0F6700A68EDD /* bg-button.png in Resources */,
+				B3B46A3F228F0F6700A68EDD /* bg-button@3x.png in Resources */,
+				B3B46A01228F0F2700A68EDD /* SourceSansPro-BlackItalic.ttf in Resources */,
+				B3B46A06228F0F2700A68EDD /* SourceSansPro-Light.ttf in Resources */,
+				B3B46A04228F0F2700A68EDD /* SourceSansPro-Bold.ttf in Resources */,
+				B3E727C423DD4A5F003B06B4 /* WalletInfoTableViewCell.xib in Resources */,
+				B3B46A0B228F0F2700A68EDD /* SourceSansPro-ExtraLightItalic.ttf in Resources */,
+				B3B46A07228F0F2700A68EDD /* SourceSansPro-Black.ttf in Resources */,
+				DD81CBC823B3A219009D3833 /* ValidateAddresses.storyboard in Resources */,
+				B3B4699D228F0C2E00A68EDD /* LaunchScreen.storyboard in Resources */,
+				DDDF95CC23C11F760057AA7F /* VerifyMessage.storyboard in Resources */,
+				DD493C00247654BC00C0D772 /* WatchOnlyWalletInfoTableViewCell.xib in Resources */,
+				DDCF25A922B8A488005FCBB9 /* Main.storyboard in Resources */,
+				DDCF259C22B8A362005FCBB9 /* Send.storyboard in Resources */,
+				10341E0C23CBBB700055DFDE /* SeedBackup.storyboard in Resources */,
+				DD36717723B44AB700D1ED67 /* More.storyboard in Resources */,
+				DD89A04123B0842400C1ECE9 /* SecurityTools.storyboard in Resources */,
+				DDCF259A22B8A347005FCBB9 /* Overview.storyboard in Resources */,
+				DD8F9D3C22BE7A5600FF8594 /* Security.storyboard in Resources */,
+				B3B46A03228F0F2700A68EDD /* SourceSansPro-Regular.ttf in Resources */,
+				B3B46A09228F0F2700A68EDD /* SourceSansPro-BoldItalic.ttf in Resources */,
+				B3C03B2323DD41EE00156D9F /* Wallets.storyboard in Resources */,
+				10C6610F23EC587B00754DED /* AccountSelectorTableViewCell.xib in Resources */,
+				DD5AB14A23BAE47A00863362 /* Help.storyboard in Resources */,
+				B3B46A98228F0F7D00A68EDD /* TransactionDetails.storyboard in Resources */,
+				DD5AB14623BAE47A00863362 /* About.storyboard in Resources */,
+				DDCF25A122B8A3D4005FCBB9 /* Settings.storyboard in Resources */,
+				DD5AB14823BAE47A00863362 /* Debug.storyboard in Resources */,
+				B3B46A05228F0F2700A68EDD /* SourceSansPro-LightItalic.ttf in Resources */,
+				100B122923E9EEAC005636A7 /* TransactionTableViewCell.xib in Resources */,
+				B37AD0A32408870B00C83D80 /* WalletAccountView.xib in Resources */,
+				DDA8154B243E56750011333F /* WalletSetup.storyboard in Resources */,
+				B3B46A08228F0F2700A68EDD /* SourceSansPro-ExtraLight.ttf in Resources */,
+				B3B46A00228F0F2700A68EDD /* inconsolata_regular.ttf in Resources */,
+				DD41737B22B1B31E00580935 /* Localizable.strings in Resources */,
+				B3B4699A228F0C2E00A68EDD /* Assets.xcassets in Resources */,
+				B3B46A0A228F0F2700A68EDD /* SourceSansPro-SemiBold.ttf in Resources */,
+				B3B46A42228F0F6700A68EDD /* progress bar-1s-200px.gif in Resources */,
+				B3B46A0E228F0F2700A68EDD /* wordlist.txt in Resources */,
+				B3E727C623DD4ABF003B06B4 /* WalletAccountTableViewCell.xib in Resources */,
+				DDD7D20925C1BCCB0013BF0A /* Privacy.storyboard in Resources */,
+				B3A8E80A23E593720094957B /* CheckableListOptionTableViewCell.xib in Resources */,
+				DDDF95D523C20AA70057AA7F /* SignMessage.storyboard in Resources */,
+				DD493C06247654BC00C0D772 /* WatchOnlyWalletTableViewCell.xib in Resources */,
+				60C7E54624ED88B8009E4569 /* Politeia.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DDB660F02486BABB0060B0C5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-        4A4B0268771D325AB934983F /* [CP] Check Pods Manifest.lock */ = {
-            isa = PBXShellScriptBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-            );
-            inputFileListPaths = (
-            );
-            inputPaths = (
-                "${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-                "${PODS_ROOT}/Manifest.lock",
-            );
-            name = "[CP] Check Pods Manifest.lock";
-            outputFileListPaths = (
-            );
-            outputPaths = (
-                "$(DERIVED_FILE_DIR)/Pods-Decred Wallet-checkManifestLockResult.txt",
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-            shellPath = /bin/sh;
-            shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-            showEnvVarsInLog = 0;
-        };
-        CF3A355769146908EB9B8041 /* [CP] Embed Pods Frameworks */ = {
-            isa = PBXShellScriptBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-            );
-            inputFileListPaths = (
-                "${PODS_ROOT}/Target Support Files/Pods-Decred Wallet/Pods-Decred Wallet-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-            );
-            name = "[CP] Embed Pods Frameworks";
-            outputFileListPaths = (
-                "${PODS_ROOT}/Target Support Files/Pods-Decred Wallet/Pods-Decred Wallet-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-            shellPath = /bin/sh;
-            shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Decred Wallet/Pods-Decred Wallet-frameworks.sh\"\n";
-            showEnvVarsInLog = 0;
-        };
+		4A4B0268771D325AB934983F /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Decred Wallet-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CF3A355769146908EB9B8041 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Decred Wallet/Pods-Decred Wallet-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Decred Wallet/Pods-Decred Wallet-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Decred Wallet/Pods-Decred Wallet-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-        B3B4698B228F0C2D00A68EDD /* Sources */ = {
-            isa = PBXSourcesBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-                DD67443825CA321C001AD0B5 /* ToolTipView.swift in Sources */,
-                B3C0D4B423E0DBF6002D984F /* SimpleTextInputDialog.swift in Sources */,
-                DDE2374823BA386C00C2A94F /* MoreMenuItemCell.swift in Sources */,
-                B3B46A10228F0F2700A68EDD /* UIView.swift in Sources */,
-                100B122C23E9EEAC005636A7 /* TransactionsViewController.swift in Sources */,
-                B3B469FE228F0F2700A68EDD /* Button.swift in Sources */,
-                60DFF5D124F75D4500624161 /* PoliteiaDetailController.swift in Sources */,
-                1034D5CF24113BF10009576C /* SimpleAlertDialog.swift in Sources */,
-                B3B46A15228F0F2700A68EDD /* UIImageView.swift in Sources */,
-                B3B46A19228F0F2700A68EDD /* StartScreenViewController.swift in Sources */,
-                B3B46A20228F0F2700A68EDD /* PinPasswordStrength.swift in Sources */,
-                2557E18B2355C9F000B6A1B7 /* CustomTabMenuView.swift in Sources */,
-                B3D474E423E57DA200B6E305 /* CheckableListOptionTableViewCell.swift in Sources */,
-                B3D21C9F2296E4F000609F23 /* ExchangeRates.swift in Sources */,
-                B3B46A86228F0F7D00A68EDD /* DropMenuButton.swift in Sources */,
-                100B122A23E9EEAC005636A7 /* TransactionTableViewCell.swift in Sources */,
-                10341E0F23CBBB7E0055DFDE /* Label.swift in Sources */,
-                10FABE4F23C7303E00BC201B /* FloatingPlaceholderTextView.swift in Sources */,
-                DD3DF86622C3F0BD00E168AB /* UILabel.swift in Sources */,
-                DD81CBC323B39DF1009D3833 /* FloatingLabelTextInput.swift in Sources */,
-                DDD65AD722A935460027CDA8 /* LicenseViewController.swift in Sources */,
-                105836B823EACD390030FDF2 /* ReceiveViewController.swift in Sources */,
-                B3E727C823DD4AD7003B06B4 /* WalletInfoTableViewCell.swift in Sources */,
-                B32EB42E23EEA24000E43D4F /* AccountDetailsViewController.swift in Sources */,
-                DD17D9CC23CE243D0017E41D /* RestoreExistingWalletViewController.swift in Sources */,
-                B39BDC4D228F798300F3FB55 /* BuildConfig.swift in Sources */,
-                B3B46A9F228F0F7D00A68EDD /* WalletLogViewController.swift in Sources */,
-                DD398ABB25C35B07003BC77D /* PrivacyManualSetupViewController.swift in Sources */,
-                2557E1892355C6FA00B6A1B7 /* NavigationMenuTabBarController.swift in Sources */,
-                102AFAC423AA2B4D007E2EBD /* ProgressView.swift in Sources */,
-                10C6611023EC587B00754DED /* AccountSelectorTableViewCell.swift in Sources */,
-                B3D474DF23E55B5D00B6E305 /* WalletSettings.swift in Sources */,
-                B3B46A1B228F0F2700A68EDD /* SecurityViewController.swift in Sources */,
-                102D724B23ED5271002DCAF2 /* TransactionDetailCell.swift in Sources */,
-                103BE67E240D1F9E007910DA /* WalletSelectorCollectionViewCell.swift in Sources */,
-                B3B46993228F0C2E00A68EDD /* AppDelegate.swift in Sources */,
-                108A2E7423DE311900B13A22 /* SelfSizedTableView.swift in Sources */,
-                B3B46A12228F0F2700A68EDD /* TextFieldDoneButton.swift in Sources */,
-                DD493BF8247327E800C0D772 /* MultipleTextInputDialog.swift in Sources */,
-                B3B46A1D228F0F2700A68EDD /* RequestPasswordViewController.swift in Sources */,
-                B3B469FA228F0F2700A68EDD /* UIColor.swift in Sources */,
-                60C7E54824ED88B8009E4569 /* PoliteiaController.swift in Sources */,
-                B34A2F8F23E8E90500B8BC01 /* WalletSyncDetailsTableViewCell.swift in Sources */,
-                10341E0B23CBBB700055DFDE /* SeedWordsDisplayTableViewCell.swift in Sources */,
-                10FABE5123C7307100BC201B /* FloatingPlaceholderBorderLayer.swift in Sources */,
-                10341E0823CBBB700055DFDE /* SeedWordsDisplayViewController.swift in Sources */,
-                DDE2374623BA386C00C2A94F /* MoreMenuViewController.swift in Sources */,
-                B3B469FD228F0F2700A68EDD /* UIViewController.swift in Sources */,
-                DD4948EC22C0E400006A35F8 /* LocalizedStrings.swift in Sources */,
-                DDAE91002435086B00FEC016 /* KeychainWrapper.swift in Sources */,
-                10D9FB9323C3956300CBF216 /* FloatingPlaceholderTextField.swift in Sources */,
-                10341E0923CBBB700055DFDE /* SeedBackupVerifyViewController.swift in Sources */,
-                B3E727CC23DD506E003B06B4 /* WalletsViewController.swift in Sources */,
-                60C7E54C24ED88F0009E4569 /* Politeia.swift in Sources */,
-                B3B46A9B228F0F7D00A68EDD /* PeerSetTableViewController.swift in Sources */,
-                60E853A825B48F9800E4CFDD /* ConnectedPeerTableViewCell.swift in Sources */,
-                B3B46A89228F0F7D00A68EDD /* keyPadButton.swift in Sources */,
-                B3D474E223E56CFD00B6E305 /* CheckableListDialogViewController.swift in Sources */,
-                60C7E54124ED8738009E4569 /* PlainHorizontalProgressBar.swift in Sources */,
-                10BA77992390059F00B67446 /* TabMenuItemView.swift in Sources */,
-                DD5AB14C23D36F7E00863362 /* AboutTableViewController.swift in Sources */,
-                B3B46AB3228F0F7D00A68EDD /* ConfirmSeedViewCell.swift in Sources */,
-                DDDF95D723C20AA70057AA7F /* SignMessageViewController.swift in Sources */,
-                DD81CBC523B39E6A009D3833 /* PaddedLabel.swift in Sources */,
-                60C7E54724ED88B8009E4569 /* PoliteiaTableViewCell.swift in Sources */,
-                B3B46A88228F0F7D00A68EDD /* UIIMage.swift in Sources */,
-                60E853A025B324C800E4CFDD /* ConnectedPeerViewcontroller.swift in Sources */,
-                B3B46A11228F0F2700A68EDD /* UITableViewExtension.swift in Sources */,
-                B379BA6523E2A2F1002CA92E /* SingleToMultiWalletMigration.swift in Sources */,
-                B3635B82229FE5870052EB4D /* QRImageScanner.swift in Sources */,
-                B3B46A2E228F0F2700A68EDD /* MenuItem.swift in Sources */,
-                B3A3EF8622936BFE00008A4E /* Reachability.swift in Sources */,
-                10C6610E23EC587B00754DED /* AccountSelectorDialog.swift in Sources */,
-                B36EFD362298617C002753B2 /* UIButton.swift in Sources */,
-                B3456D2523D91CF600B04860 /* RoundedView.swift in Sources */,
-                B3B469FC228F0F2700A68EDD /* String.swift in Sources */,
-                DD89A04323B08CF800C1ECE9 /* SecurityToolsViewController.swift in Sources */,
-                DDDF95CE23C11F760057AA7F /* VerifyMessageViewController.swift in Sources */,
-                DDA2F7CE24375FEF00A3DC7C /* StatisticsViewController.swift in Sources */,
-                10B7818223F066DA00AD2709 /* TransactionInputDetailCell.swift in Sources */,
-                B3B46A9A228F0F7D00A68EDD /* SettingsController.swift in Sources */,
-                10FABE4B23C72D6800BC201B /* FloatingPlaceholderInputProtocol.swift in Sources */,
-                B3B46A1F228F0F2700A68EDD /* RequestPinViewController.swift in Sources */,
-                10341E0A23CBBB700055DFDE /* SeedBackupVerifyTableViewCell.swift in Sources */,
-                B3B9432923E4D0B30088EC3E /* WalletSettingsViewController.swift in Sources */,
-                250D77BD23F2BF0F00CDC256 /* DecredAddressURI.swift in Sources */,
-                B3A3EF88229375D100008A4E /* Date.swift in Sources */,
-                B3B46A21228F0F2700A68EDD /* SecurityCodeRequestBaseViewController.swift in Sources */,
-                B3A3EF922295956300008A4E /* SendViewController.swift in Sources */,
-                B3E727CA23DD4AE7003B06B4 /* WalletAccountTableViewCell.swift in Sources */,
-                B3E727CE23DE0FCC003B06B4 /* Wallet.swift in Sources */,
-                DDEEEE1825AB1B8E00794B67 /* PrivacySetupViewController.swift in Sources */,
-                B3B46A8C228F0F7D00A68EDD /* Utils.swift in Sources */,
-                B304B39423F202A400B81798 /* Settings.swift in Sources */,
-                B3B46A34228F0F2700A68EDD /* TransactionNotification.swift in Sources */,
-                B37AD0A524088A6700C83D80 /* WalletAccountView.swift in Sources */,
-                DD81CBCA23B3A298009D3833 /* ValidateAddressesViewController.swift in Sources */,
-                B3B46A87228F0F7D00A68EDD /* Data.swift in Sources */,
-                B3B46AB6228F0F7D00A68EDD /* Storyboard.swift in Sources */,
-                B3B46A37228F0F2700A68EDD /* SpendingPinOrPassword.swift in Sources */,
-                6007D38B24F406AA000EC5CB /* Response.swift in Sources */,
-                25A4331C2373D0330018FFCF /* SyncManager.swift in Sources */,
-                B3B46AAC228F0F7D00A68EDD /* RecoveryWalletSeedWordCell.swift in Sources */,
-                DDAE91022435092200FEC016 /* KeychainItemAccessibility.swift in Sources */,
-                B3B46A39228F0F2700A68EDD /* StartupPinOrPassword.swift in Sources */,
-                B3B46A8F228F0F7D00A68EDD /* ConfirmToSendFundViewController.swift in Sources */,
-                60E853A425B4805200E4CFDD /* PeerInfo.swift in Sources */,
-                B3B46A38228F0F2700A68EDD /* Dcrlibwallet.swift in Sources */,
-                100B122E23E9EECB005636A7 /* RestoreExistingWalletSuccessViewController.swift in Sources */,
-                B3B46A36228F0F2700A68EDD /* WalletLoader.swift in Sources */,
-                C8BBC3AE2450CE1E001A5A9E /* SuffixTextField.swift in Sources */,
-                AD24C23D2343E445009583C9 /* NotificationsManager.swift in Sources */,
-                DD493C04247654BC00C0D772 /* WatchOnlyWalletTableViewCell.swift in Sources */,
-                10B7818523F0693C00AD2709 /* TransactionOutputDetailCell.swift in Sources */,
-                DD02AC6523969440004A73E3 /* MoreMenuItem.swift in Sources */,
-                B3B46AA7228F0F7D00A68EDD /* CurrencyConversionOptionsViewController.swift in Sources */,
-                DD89A04723B091FF00C1ECE9 /* SecurityToolsItemCell.swift in Sources */,
-                60C7E54B24ED88F0009E4569 /* PoliteiaStatus.swift in Sources */,
-                25E63F4E23312B2C009CD53E /* NavMenuFloatingButtons.swift in Sources */,
-                DD569298259B9E40004D4BE6 /* PrivacyViewController.swift in Sources */,
-                B3B46AB1228F0F7D00A68EDD /* SeedCheckActiveCellView.swift in Sources */,
-                B3B46A32228F0F2700A68EDD /* OverviewViewController.swift in Sources */,
-                10341E0723CBBB700055DFDE /* SeedBackupSuccessViewController.swift in Sources */,
-                6007D38D24F42089000EC5CB /* PoliteiaNotification.swift in Sources */,
-                DD5AB15023D612C800863362 /* HelpTableViewController.swift in Sources */,
-                DD89A04523B08FDD00C1ECE9 /* SecurityToolsItem.swift in Sources */,
-                B35C55D8232FED610006A765 /* Transaction.swift in Sources */,
-                B3B46A8A228F0F7D00A68EDD /* customUImage.swift in Sources */,
-                DD5AB14E23D4C12C00863362 /* DebugTableViewController.swift in Sources */,
-                B3B469FB228F0F2700A68EDD /* Extensions.swift in Sources */,
-                B3B46A0D228F0F2700A68EDD /* Constants.swift in Sources */,
-                DDAE91042435092200FEC016 /* ErrorMessageForLA.swift in Sources */,
-                10945CDA23F3DB0C00BBE242 /* TransactionOverviewCell.swift in Sources */,
-                60778AE026274DA9006B1FC2 /* WalletMixerCell.swift in Sources */,
-                10341E0D23CBBB700055DFDE /* SeedBackupReminderViewController.swift in Sources */,
-                B34A2F9123E8ED1500B8BC01 /* MultiWalletSyncDetailsLoader.swift in Sources */,
-                10D9FB9623C3956300CBF216 /* FloatingPlaceholderLabel.swift in Sources */,
-                DD493C02247654BC00C0D772 /* WatchOnlyWalletInfoTableViewCell.swift in Sources */,
-                B3967B3D22A75BD400E14432 /* UITableView.swift in Sources */,
-                B3C0D4B623E0FBA5002D984F /* SimpleOkCancelDialog.swift in Sources */,
-                DDA8734E245F69C00029A13D /* CIImage.swift in Sources */,
-                B3C0D4AF23DF9C45002D984F /* Security.swift in Sources */,
-                B3B46A17228F0F2700A68EDD /* ContouredButton.swift in Sources */,
-                B3B46A18228F0F2700A68EDD /* DropDownSearchField.swift in Sources */,
-                B3B46A97228F0F7D00A68EDD /* TransactionDetailsViewController.swift in Sources */,
-                DD398AB825C35B03003BC77D /* PrivacySetupTypeViewController.swift in Sources */,
-                6004FFB825CC5D0100D5A25C /* LoadingView.swift in Sources */,
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-        };
-        DDB660EE2486BABB0060B0C5 /* Sources */ = {
-            isa = PBXSourcesBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-                DD2E176E24A95BAC001AF94D /* RestoreExistingWalletUITest.swift in Sources */,
-                DDB660F52486BABB0060B0C5 /* Decred_WalletUITests.swift in Sources */,
-                DD2E177224A95CA4001AF94D /* SeedBackupUITest.swift in Sources */,
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-        };
+		B3B4698B228F0C2D00A68EDD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DD67443825CA321C001AD0B5 /* ToolTipView.swift in Sources */,
+				B3C0D4B423E0DBF6002D984F /* SimpleTextInputDialog.swift in Sources */,
+				DDE2374823BA386C00C2A94F /* MoreMenuItemCell.swift in Sources */,
+				B3B46A10228F0F2700A68EDD /* UIView.swift in Sources */,
+				100B122C23E9EEAC005636A7 /* TransactionsViewController.swift in Sources */,
+				B3B469FE228F0F2700A68EDD /* Button.swift in Sources */,
+				60DFF5D124F75D4500624161 /* PoliteiaDetailController.swift in Sources */,
+				1034D5CF24113BF10009576C /* SimpleAlertDialog.swift in Sources */,
+				B3B46A15228F0F2700A68EDD /* UIImageView.swift in Sources */,
+				B3B46A19228F0F2700A68EDD /* StartScreenViewController.swift in Sources */,
+				B3B46A20228F0F2700A68EDD /* PinPasswordStrength.swift in Sources */,
+				2557E18B2355C9F000B6A1B7 /* CustomTabMenuView.swift in Sources */,
+				B3D474E423E57DA200B6E305 /* CheckableListOptionTableViewCell.swift in Sources */,
+				B3D21C9F2296E4F000609F23 /* ExchangeRates.swift in Sources */,
+				B3B46A86228F0F7D00A68EDD /* DropMenuButton.swift in Sources */,
+				100B122A23E9EEAC005636A7 /* TransactionTableViewCell.swift in Sources */,
+				10341E0F23CBBB7E0055DFDE /* Label.swift in Sources */,
+				10FABE4F23C7303E00BC201B /* FloatingPlaceholderTextView.swift in Sources */,
+				DD3DF86622C3F0BD00E168AB /* UILabel.swift in Sources */,
+				DD81CBC323B39DF1009D3833 /* FloatingLabelTextInput.swift in Sources */,
+				DDD65AD722A935460027CDA8 /* LicenseViewController.swift in Sources */,
+				105836B823EACD390030FDF2 /* ReceiveViewController.swift in Sources */,
+				B3E727C823DD4AD7003B06B4 /* WalletInfoTableViewCell.swift in Sources */,
+				B32EB42E23EEA24000E43D4F /* AccountDetailsViewController.swift in Sources */,
+				DD17D9CC23CE243D0017E41D /* RestoreExistingWalletViewController.swift in Sources */,
+				B39BDC4D228F798300F3FB55 /* BuildConfig.swift in Sources */,
+				B3B46A9F228F0F7D00A68EDD /* WalletLogViewController.swift in Sources */,
+				DD398ABB25C35B07003BC77D /* PrivacyManualSetupViewController.swift in Sources */,
+				2557E1892355C6FA00B6A1B7 /* NavigationMenuTabBarController.swift in Sources */,
+				102AFAC423AA2B4D007E2EBD /* ProgressView.swift in Sources */,
+				10C6611023EC587B00754DED /* AccountSelectorTableViewCell.swift in Sources */,
+				B3D474DF23E55B5D00B6E305 /* WalletSettings.swift in Sources */,
+				B3B46A1B228F0F2700A68EDD /* SecurityViewController.swift in Sources */,
+				102D724B23ED5271002DCAF2 /* TransactionDetailCell.swift in Sources */,
+				103BE67E240D1F9E007910DA /* WalletSelectorCollectionViewCell.swift in Sources */,
+				B3B46993228F0C2E00A68EDD /* AppDelegate.swift in Sources */,
+				108A2E7423DE311900B13A22 /* SelfSizedTableView.swift in Sources */,
+				B3B46A12228F0F2700A68EDD /* TextFieldDoneButton.swift in Sources */,
+				DD493BF8247327E800C0D772 /* MultipleTextInputDialog.swift in Sources */,
+				B3B46A1D228F0F2700A68EDD /* RequestPasswordViewController.swift in Sources */,
+				B3B469FA228F0F2700A68EDD /* UIColor.swift in Sources */,
+				60C7E54824ED88B8009E4569 /* PoliteiaController.swift in Sources */,
+				B34A2F8F23E8E90500B8BC01 /* WalletSyncDetailsTableViewCell.swift in Sources */,
+				10341E0B23CBBB700055DFDE /* SeedWordsDisplayTableViewCell.swift in Sources */,
+				10FABE5123C7307100BC201B /* FloatingPlaceholderBorderLayer.swift in Sources */,
+				10341E0823CBBB700055DFDE /* SeedWordsDisplayViewController.swift in Sources */,
+				DDE2374623BA386C00C2A94F /* MoreMenuViewController.swift in Sources */,
+				B3B469FD228F0F2700A68EDD /* UIViewController.swift in Sources */,
+				DD4948EC22C0E400006A35F8 /* LocalizedStrings.swift in Sources */,
+				DDAE91002435086B00FEC016 /* KeychainWrapper.swift in Sources */,
+				10D9FB9323C3956300CBF216 /* FloatingPlaceholderTextField.swift in Sources */,
+				10341E0923CBBB700055DFDE /* SeedBackupVerifyViewController.swift in Sources */,
+				B3E727CC23DD506E003B06B4 /* WalletsViewController.swift in Sources */,
+				60C7E54C24ED88F0009E4569 /* Politeia.swift in Sources */,
+				B3B46A9B228F0F7D00A68EDD /* PeerSetTableViewController.swift in Sources */,
+				60E853A825B48F9800E4CFDD /* ConnectedPeerTableViewCell.swift in Sources */,
+				B3B46A89228F0F7D00A68EDD /* keyPadButton.swift in Sources */,
+				B3D474E223E56CFD00B6E305 /* CheckableListDialogViewController.swift in Sources */,
+				60C7E54124ED8738009E4569 /* PlainHorizontalProgressBar.swift in Sources */,
+				10BA77992390059F00B67446 /* TabMenuItemView.swift in Sources */,
+				DD5AB14C23D36F7E00863362 /* AboutTableViewController.swift in Sources */,
+				B3B46AB3228F0F7D00A68EDD /* ConfirmSeedViewCell.swift in Sources */,
+				DDDF95D723C20AA70057AA7F /* SignMessageViewController.swift in Sources */,
+				DD81CBC523B39E6A009D3833 /* PaddedLabel.swift in Sources */,
+				60C7E54724ED88B8009E4569 /* PoliteiaTableViewCell.swift in Sources */,
+				B3B46A88228F0F7D00A68EDD /* UIIMage.swift in Sources */,
+				60E853A025B324C800E4CFDD /* ConnectedPeerViewcontroller.swift in Sources */,
+				B3B46A11228F0F2700A68EDD /* UITableViewExtension.swift in Sources */,
+				B379BA6523E2A2F1002CA92E /* SingleToMultiWalletMigration.swift in Sources */,
+				B3635B82229FE5870052EB4D /* QRImageScanner.swift in Sources */,
+				B3B46A2E228F0F2700A68EDD /* MenuItem.swift in Sources */,
+				B3A3EF8622936BFE00008A4E /* Reachability.swift in Sources */,
+				10C6610E23EC587B00754DED /* AccountSelectorDialog.swift in Sources */,
+				B36EFD362298617C002753B2 /* UIButton.swift in Sources */,
+				B3456D2523D91CF600B04860 /* RoundedView.swift in Sources */,
+				B3B469FC228F0F2700A68EDD /* String.swift in Sources */,
+				DD89A04323B08CF800C1ECE9 /* SecurityToolsViewController.swift in Sources */,
+				DDDF95CE23C11F760057AA7F /* VerifyMessageViewController.swift in Sources */,
+				DDA2F7CE24375FEF00A3DC7C /* StatisticsViewController.swift in Sources */,
+				10B7818223F066DA00AD2709 /* TransactionInputDetailCell.swift in Sources */,
+				B3B46A9A228F0F7D00A68EDD /* SettingsController.swift in Sources */,
+				10FABE4B23C72D6800BC201B /* FloatingPlaceholderInputProtocol.swift in Sources */,
+				B3B46A1F228F0F2700A68EDD /* RequestPinViewController.swift in Sources */,
+				10341E0A23CBBB700055DFDE /* SeedBackupVerifyTableViewCell.swift in Sources */,
+				B3B9432923E4D0B30088EC3E /* WalletSettingsViewController.swift in Sources */,
+				250D77BD23F2BF0F00CDC256 /* DecredAddressURI.swift in Sources */,
+				B3A3EF88229375D100008A4E /* Date.swift in Sources */,
+				B3B46A21228F0F2700A68EDD /* SecurityCodeRequestBaseViewController.swift in Sources */,
+				B3A3EF922295956300008A4E /* SendViewController.swift in Sources */,
+				B3E727CA23DD4AE7003B06B4 /* WalletAccountTableViewCell.swift in Sources */,
+				B3E727CE23DE0FCC003B06B4 /* Wallet.swift in Sources */,
+				DDEEEE1825AB1B8E00794B67 /* PrivacySetupViewController.swift in Sources */,
+				B3B46A8C228F0F7D00A68EDD /* Utils.swift in Sources */,
+				B304B39423F202A400B81798 /* Settings.swift in Sources */,
+				B3B46A34228F0F2700A68EDD /* TransactionNotification.swift in Sources */,
+				B37AD0A524088A6700C83D80 /* WalletAccountView.swift in Sources */,
+				DD81CBCA23B3A298009D3833 /* ValidateAddressesViewController.swift in Sources */,
+				B3B46A87228F0F7D00A68EDD /* Data.swift in Sources */,
+				B3B46AB6228F0F7D00A68EDD /* Storyboard.swift in Sources */,
+				B3B46A37228F0F2700A68EDD /* SpendingPinOrPassword.swift in Sources */,
+				6007D38B24F406AA000EC5CB /* Response.swift in Sources */,
+				25A4331C2373D0330018FFCF /* SyncManager.swift in Sources */,
+				B3B46AAC228F0F7D00A68EDD /* RecoveryWalletSeedWordCell.swift in Sources */,
+				DDAE91022435092200FEC016 /* KeychainItemAccessibility.swift in Sources */,
+				B3B46A39228F0F2700A68EDD /* StartupPinOrPassword.swift in Sources */,
+				B3B46A8F228F0F7D00A68EDD /* ConfirmToSendFundViewController.swift in Sources */,
+				60E853A425B4805200E4CFDD /* PeerInfo.swift in Sources */,
+				B3B46A38228F0F2700A68EDD /* Dcrlibwallet.swift in Sources */,
+				100B122E23E9EECB005636A7 /* RestoreExistingWalletSuccessViewController.swift in Sources */,
+				B3B46A36228F0F2700A68EDD /* WalletLoader.swift in Sources */,
+				C8BBC3AE2450CE1E001A5A9E /* SuffixTextField.swift in Sources */,
+				AD24C23D2343E445009583C9 /* NotificationsManager.swift in Sources */,
+				DD493C04247654BC00C0D772 /* WatchOnlyWalletTableViewCell.swift in Sources */,
+				10B7818523F0693C00AD2709 /* TransactionOutputDetailCell.swift in Sources */,
+				DD02AC6523969440004A73E3 /* MoreMenuItem.swift in Sources */,
+				B3B46AA7228F0F7D00A68EDD /* CurrencyConversionOptionsViewController.swift in Sources */,
+				DD89A04723B091FF00C1ECE9 /* SecurityToolsItemCell.swift in Sources */,
+				60C7E54B24ED88F0009E4569 /* PoliteiaStatus.swift in Sources */,
+				25E63F4E23312B2C009CD53E /* NavMenuFloatingButtons.swift in Sources */,
+				DD569298259B9E40004D4BE6 /* PrivacyViewController.swift in Sources */,
+				B3B46AB1228F0F7D00A68EDD /* SeedCheckActiveCellView.swift in Sources */,
+				B3B46A32228F0F2700A68EDD /* OverviewViewController.swift in Sources */,
+				10341E0723CBBB700055DFDE /* SeedBackupSuccessViewController.swift in Sources */,
+				6007D38D24F42089000EC5CB /* PoliteiaNotification.swift in Sources */,
+				DD5AB15023D612C800863362 /* HelpTableViewController.swift in Sources */,
+				DD89A04523B08FDD00C1ECE9 /* SecurityToolsItem.swift in Sources */,
+				B35C55D8232FED610006A765 /* Transaction.swift in Sources */,
+				B3B46A8A228F0F7D00A68EDD /* customUImage.swift in Sources */,
+				DD5AB14E23D4C12C00863362 /* DebugTableViewController.swift in Sources */,
+				B3B469FB228F0F2700A68EDD /* Extensions.swift in Sources */,
+				B3B46A0D228F0F2700A68EDD /* Constants.swift in Sources */,
+				DDAE91042435092200FEC016 /* ErrorMessageForLA.swift in Sources */,
+				10945CDA23F3DB0C00BBE242 /* TransactionOverviewCell.swift in Sources */,
+				60778AE026274DA9006B1FC2 /* WalletMixerCell.swift in Sources */,
+				10341E0D23CBBB700055DFDE /* SeedBackupReminderViewController.swift in Sources */,
+				B34A2F9123E8ED1500B8BC01 /* MultiWalletSyncDetailsLoader.swift in Sources */,
+				10D9FB9623C3956300CBF216 /* FloatingPlaceholderLabel.swift in Sources */,
+				DD493C02247654BC00C0D772 /* WatchOnlyWalletInfoTableViewCell.swift in Sources */,
+				B3967B3D22A75BD400E14432 /* UITableView.swift in Sources */,
+				B3C0D4B623E0FBA5002D984F /* SimpleOkCancelDialog.swift in Sources */,
+				DDA8734E245F69C00029A13D /* CIImage.swift in Sources */,
+				B3C0D4AF23DF9C45002D984F /* Security.swift in Sources */,
+				B3B46A17228F0F2700A68EDD /* ContouredButton.swift in Sources */,
+				B3B46A18228F0F2700A68EDD /* DropDownSearchField.swift in Sources */,
+				B3B46A97228F0F7D00A68EDD /* TransactionDetailsViewController.swift in Sources */,
+				DD398AB825C35B03003BC77D /* PrivacySetupTypeViewController.swift in Sources */,
+				6004FFB825CC5D0100D5A25C /* LoadingView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DDB660EE2486BABB0060B0C5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DD2E176E24A95BAC001AF94D /* RestoreExistingWalletUITest.swift in Sources */,
+				DDB660F52486BABB0060B0C5 /* Decred_WalletUITests.swift in Sources */,
+				DD2E177224A95CA4001AF94D /* SeedBackupUITest.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-        DDB660F82486BABB0060B0C5 /* PBXTargetDependency */ = {
-            isa = PBXTargetDependency;
-            target = B3B4698E228F0C2D00A68EDD /* Decred Wallet */;
-            targetProxy = DDB660F72486BABB0060B0C5 /* PBXContainerItemProxy */;
-        };
+		DDB660F82486BABB0060B0C5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B3B4698E228F0C2D00A68EDD /* Decred Wallet */;
+			targetProxy = DDB660F72486BABB0060B0C5 /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
-        B3B4699B228F0C2E00A68EDD /* LaunchScreen.storyboard */ = {
-            isa = PBXVariantGroup;
-            children = (
-                B3B4699C228F0C2E00A68EDD /* Base */,
-            );
-            name = LaunchScreen.storyboard;
-            sourceTree = "<group>";
-        };
-        DD41737D22B1B31E00580935 /* Localizable.strings */ = {
-            isa = PBXVariantGroup;
-            children = (
-                DD41737C22B1B31E00580935 /* en */,
-                DD41737E22B1B32500580935 /* ru-RU */,
-                DD3DF86722C42B3E00E168AB /* zh-Hans */,
-                DD452ED922CA93CB00A12378 /* es */,
-                DD443DD422C768A000EEAB95 /* vi */,
-                DDFB922722C8FF2D00F46FBE /* pt-BR */,
-                DD36EE33247020C30011C335 /* pl */,
-                6091E9A8255000CE0028E67F /* fr */,
-            );
-            name = Localizable.strings;
-            sourceTree = "<group>";
-        };
+		B3B4699B228F0C2E00A68EDD /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				B3B4699C228F0C2E00A68EDD /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		DD41737D22B1B31E00580935 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				DD41737C22B1B31E00580935 /* en */,
+				DD41737E22B1B32500580935 /* ru-RU */,
+				DD3DF86722C42B3E00E168AB /* zh-Hans */,
+				DD452ED922CA93CB00A12378 /* es */,
+				DD443DD422C768A000EEAB95 /* vi */,
+				DDFB922722C8FF2D00F46FBE /* pt-BR */,
+				DD36EE33247020C30011C335 /* pl */,
+				6091E9A8255000CE0028E67F /* fr */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-        B30A37CC228F3AE100F78629 /* Testnet Debug */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ALWAYS_SEARCH_USER_PATHS = NO;
-                CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
-                CLANG_ANALYZER_NONNULL = YES;
-                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-                CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-                CLANG_CXX_LIBRARY = "libc++";
-                CLANG_ENABLE_MODULES = YES;
-                CLANG_ENABLE_OBJC_ARC = YES;
-                CLANG_ENABLE_OBJC_WEAK = YES;
-                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-                CLANG_WARN_BOOL_CONVERSION = YES;
-                CLANG_WARN_COMMA = YES;
-                CLANG_WARN_CONSTANT_CONVERSION = YES;
-                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-                CLANG_WARN_EMPTY_BODY = YES;
-                CLANG_WARN_ENUM_CONVERSION = YES;
-                CLANG_WARN_INFINITE_RECURSION = YES;
-                CLANG_WARN_INT_CONVERSION = YES;
-                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-                CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-                CLANG_WARN_STRICT_PROTOTYPES = YES;
-                CLANG_WARN_SUSPICIOUS_MOVE = YES;
-                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-                CLANG_WARN_UNREACHABLE_CODE = YES;
-                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-                CODE_SIGN_IDENTITY = "iPhone Developer";
-                COPY_PHASE_STRIP = NO;
-                DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-                ENABLE_STRICT_OBJC_MSGSEND = YES;
-                ENABLE_TESTABILITY = YES;
-                GCC_C_LANGUAGE_STANDARD = gnu11;
-                GCC_DYNAMIC_NO_PIC = NO;
-                GCC_NO_COMMON_BLOCKS = YES;
-                GCC_OPTIMIZATION_LEVEL = 0;
-                GCC_PREPROCESSOR_DEFINITIONS = (
-                    "DEBUG=1",
-                    "$(inherited)",
-                );
-                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-                GCC_WARN_UNDECLARED_SELECTOR = YES;
-                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-                GCC_WARN_UNUSED_FUNCTION = YES;
-                GCC_WARN_UNUSED_VARIABLE = YES;
-                IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-                MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
-                MTL_FAST_MATH = YES;
-                ONLY_ACTIVE_ARCH = YES;
-                OTHER_SWIFT_FLAGS = "-DIsTestnet";
-                SDKROOT = iphoneos;
-                SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-                SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-            };
-            name = "Testnet Debug";
-        };
-        B30A37CD228F3AE100F78629 /* Testnet Debug */ = {
-            isa = XCBuildConfiguration;
-            baseConfigurationReference = B107091A1D996651AB5D8891 /* Pods-Decred Wallet.testnet debug.xcconfig */;
-            buildSettings = {
-                ASSETCATALOG_COMPILER_APPICON_NAME = AppIconTestnet;
-                CODE_SIGN_IDENTITY = "iPhone Developer";
-                CODE_SIGN_STYLE = Automatic;
-                DEVELOPMENT_TEAM = "";
-                ENABLE_BITCODE = NO;
-                FRAMEWORK_SEARCH_PATHS = (
-                    "$(inherited)",
-                    "$(PROJECT_DIR)/libs",
-                );
-                INFOPLIST_FILE = "Decred Wallet/Info.plist";
-                LD_RUNPATH_SEARCH_PATHS = (
-                    "$(inherited)",
-                    "@executable_path/Frameworks",
-                );
-                MARKETING_VERSION = 1.5.2;
-                PRODUCT_BUNDLE_IDENTIFIER = com.decred.dcrios.testnet3;
-                PRODUCT_NAME = "$(TARGET_NAME) Testnet";
-                PROVISIONING_PROFILE_SPECIFIER = "";
-                SWIFT_VERSION = 5.0;
-                TARGETED_DEVICE_FAMILY = "1,2";
-            };
-            name = "Testnet Debug";
-        };
-        B30A37CE228F3AF000F78629 /* Testnet Release */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ALWAYS_SEARCH_USER_PATHS = NO;
-                CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
-                CLANG_ANALYZER_NONNULL = YES;
-                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-                CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-                CLANG_CXX_LIBRARY = "libc++";
-                CLANG_ENABLE_MODULES = YES;
-                CLANG_ENABLE_OBJC_ARC = YES;
-                CLANG_ENABLE_OBJC_WEAK = YES;
-                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-                CLANG_WARN_BOOL_CONVERSION = YES;
-                CLANG_WARN_COMMA = YES;
-                CLANG_WARN_CONSTANT_CONVERSION = YES;
-                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-                CLANG_WARN_EMPTY_BODY = YES;
-                CLANG_WARN_ENUM_CONVERSION = YES;
-                CLANG_WARN_INFINITE_RECURSION = YES;
-                CLANG_WARN_INT_CONVERSION = YES;
-                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-                CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-                CLANG_WARN_STRICT_PROTOTYPES = YES;
-                CLANG_WARN_SUSPICIOUS_MOVE = YES;
-                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-                CLANG_WARN_UNREACHABLE_CODE = YES;
-                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-                CODE_SIGN_IDENTITY = "iPhone Developer";
-                COPY_PHASE_STRIP = NO;
-                DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-                ENABLE_NS_ASSERTIONS = NO;
-                ENABLE_STRICT_OBJC_MSGSEND = YES;
-                GCC_C_LANGUAGE_STANDARD = gnu11;
-                GCC_NO_COMMON_BLOCKS = YES;
-                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-                GCC_WARN_UNDECLARED_SELECTOR = YES;
-                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-                GCC_WARN_UNUSED_FUNCTION = YES;
-                GCC_WARN_UNUSED_VARIABLE = YES;
-                IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-                MTL_ENABLE_DEBUG_INFO = NO;
-                MTL_FAST_MATH = YES;
-                OTHER_SWIFT_FLAGS = "-DIsTestnet";
-                SDKROOT = iphoneos;
-                SWIFT_COMPILATION_MODE = wholemodule;
-                SWIFT_OPTIMIZATION_LEVEL = "-O";
-                VALIDATE_PRODUCT = YES;
-            };
-            name = "Testnet Release";
-        };
-        B30A37CF228F3AF000F78629 /* Testnet Release */ = {
-            isa = XCBuildConfiguration;
-            baseConfigurationReference = D59C7DB99807D17630259A55 /* Pods-Decred Wallet.testnet release.xcconfig */;
-            buildSettings = {
-                ASSETCATALOG_COMPILER_APPICON_NAME = AppIconTestnet;
-                CODE_SIGN_IDENTITY = "iPhone Developer";
-                CODE_SIGN_STYLE = Automatic;
-                DEVELOPMENT_TEAM = "";
-                ENABLE_BITCODE = NO;
-                FRAMEWORK_SEARCH_PATHS = (
-                    "$(inherited)",
-                    "$(PROJECT_DIR)/libs",
-                );
-                INFOPLIST_FILE = "Decred Wallet/Info.plist";
-                LD_RUNPATH_SEARCH_PATHS = (
-                    "$(inherited)",
-                    "@executable_path/Frameworks",
-                );
-                MARKETING_VERSION = 1.5.2;
-                PRODUCT_BUNDLE_IDENTIFIER = com.decred.dcrios.testnet3;
-                PRODUCT_NAME = "$(TARGET_NAME) Testnet";
-                PROVISIONING_PROFILE_SPECIFIER = "";
-                SWIFT_VERSION = 5.0;
-                TARGETED_DEVICE_FAMILY = "1,2";
-            };
-            name = "Testnet Release";
-        };
-        B3B4699F228F0C2E00A68EDD /* Mainnet Debug */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ALWAYS_SEARCH_USER_PATHS = NO;
-                CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
-                CLANG_ANALYZER_NONNULL = YES;
-                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-                CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-                CLANG_CXX_LIBRARY = "libc++";
-                CLANG_ENABLE_MODULES = YES;
-                CLANG_ENABLE_OBJC_ARC = YES;
-                CLANG_ENABLE_OBJC_WEAK = YES;
-                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-                CLANG_WARN_BOOL_CONVERSION = YES;
-                CLANG_WARN_COMMA = YES;
-                CLANG_WARN_CONSTANT_CONVERSION = YES;
-                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-                CLANG_WARN_EMPTY_BODY = YES;
-                CLANG_WARN_ENUM_CONVERSION = YES;
-                CLANG_WARN_INFINITE_RECURSION = YES;
-                CLANG_WARN_INT_CONVERSION = YES;
-                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-                CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-                CLANG_WARN_STRICT_PROTOTYPES = YES;
-                CLANG_WARN_SUSPICIOUS_MOVE = YES;
-                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-                CLANG_WARN_UNREACHABLE_CODE = YES;
-                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-                CODE_SIGN_IDENTITY = "iPhone Developer";
-                COPY_PHASE_STRIP = NO;
-                DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-                ENABLE_STRICT_OBJC_MSGSEND = YES;
-                ENABLE_TESTABILITY = YES;
-                GCC_C_LANGUAGE_STANDARD = gnu11;
-                GCC_DYNAMIC_NO_PIC = NO;
-                GCC_NO_COMMON_BLOCKS = YES;
-                GCC_OPTIMIZATION_LEVEL = 0;
-                GCC_PREPROCESSOR_DEFINITIONS = (
-                    "DEBUG=1",
-                    "$(inherited)",
-                );
-                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-                GCC_WARN_UNDECLARED_SELECTOR = YES;
-                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-                GCC_WARN_UNUSED_FUNCTION = YES;
-                GCC_WARN_UNUSED_VARIABLE = YES;
-                IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-                MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
-                MTL_FAST_MATH = YES;
-                ONLY_ACTIVE_ARCH = YES;
-                SDKROOT = iphoneos;
-                SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-                SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-            };
-            name = "Mainnet Debug";
-        };
-        B3B469A0228F0C2E00A68EDD /* Mainnet Release */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ALWAYS_SEARCH_USER_PATHS = NO;
-                CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
-                CLANG_ANALYZER_NONNULL = YES;
-                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-                CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-                CLANG_CXX_LIBRARY = "libc++";
-                CLANG_ENABLE_MODULES = YES;
-                CLANG_ENABLE_OBJC_ARC = YES;
-                CLANG_ENABLE_OBJC_WEAK = YES;
-                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-                CLANG_WARN_BOOL_CONVERSION = YES;
-                CLANG_WARN_COMMA = YES;
-                CLANG_WARN_CONSTANT_CONVERSION = YES;
-                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-                CLANG_WARN_EMPTY_BODY = YES;
-                CLANG_WARN_ENUM_CONVERSION = YES;
-                CLANG_WARN_INFINITE_RECURSION = YES;
-                CLANG_WARN_INT_CONVERSION = YES;
-                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-                CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-                CLANG_WARN_STRICT_PROTOTYPES = YES;
-                CLANG_WARN_SUSPICIOUS_MOVE = YES;
-                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-                CLANG_WARN_UNREACHABLE_CODE = YES;
-                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-                CODE_SIGN_IDENTITY = "iPhone Developer";
-                COPY_PHASE_STRIP = NO;
-                DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-                ENABLE_NS_ASSERTIONS = NO;
-                ENABLE_STRICT_OBJC_MSGSEND = YES;
-                GCC_C_LANGUAGE_STANDARD = gnu11;
-                GCC_NO_COMMON_BLOCKS = YES;
-                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-                GCC_WARN_UNDECLARED_SELECTOR = YES;
-                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-                GCC_WARN_UNUSED_FUNCTION = YES;
-                GCC_WARN_UNUSED_VARIABLE = YES;
-                IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-                MTL_ENABLE_DEBUG_INFO = NO;
-                MTL_FAST_MATH = YES;
-                SDKROOT = iphoneos;
-                SWIFT_COMPILATION_MODE = wholemodule;
-                SWIFT_OPTIMIZATION_LEVEL = "-O";
-                VALIDATE_PRODUCT = YES;
-            };
-            name = "Mainnet Release";
-        };
-        B3B469A2228F0C2E00A68EDD /* Mainnet Debug */ = {
-            isa = XCBuildConfiguration;
-            baseConfigurationReference = 6A0625AB1C6ACD2EC77F544F /* Pods-Decred Wallet.mainnet debug.xcconfig */;
-            buildSettings = {
-                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-                CODE_SIGN_IDENTITY = "iPhone Developer";
-                CODE_SIGN_STYLE = Automatic;
-                DEVELOPMENT_TEAM = "";
-                ENABLE_BITCODE = NO;
-                FRAMEWORK_SEARCH_PATHS = (
-                    "$(inherited)",
-                    "$(PROJECT_DIR)/libs",
-                );
-                INFOPLIST_FILE = "Decred Wallet/Info.plist";
-                LD_RUNPATH_SEARCH_PATHS = (
-                    "$(inherited)",
-                    "@executable_path/Frameworks",
-                );
-                MARKETING_VERSION = 1.5.2;
-                PRODUCT_BUNDLE_IDENTIFIER = com.decred.dcrios.mainnet;
-                PRODUCT_NAME = "$(TARGET_NAME)";
-                PROVISIONING_PROFILE_SPECIFIER = "";
-                SWIFT_VERSION = 5.0;
-                TARGETED_DEVICE_FAMILY = "1,2";
-            };
-            name = "Mainnet Debug";
-        };
-        B3B469A3228F0C2E00A68EDD /* Mainnet Release */ = {
-            isa = XCBuildConfiguration;
-            baseConfigurationReference = 23F5A25CDDC0ADF47F98ED95 /* Pods-Decred Wallet.mainnet release.xcconfig */;
-            buildSettings = {
-                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-                CODE_SIGN_IDENTITY = "iPhone Developer";
-                CODE_SIGN_STYLE = Automatic;
-                DEVELOPMENT_TEAM = "";
-                ENABLE_BITCODE = NO;
-                FRAMEWORK_SEARCH_PATHS = (
-                    "$(inherited)",
-                    "$(PROJECT_DIR)/libs",
-                );
-                INFOPLIST_FILE = "Decred Wallet/Info.plist";
-                LD_RUNPATH_SEARCH_PATHS = (
-                    "$(inherited)",
-                    "@executable_path/Frameworks",
-                );
-                MARKETING_VERSION = 1.5.2;
-                PRODUCT_BUNDLE_IDENTIFIER = com.decred.dcrios.mainnet;
-                PRODUCT_NAME = "$(TARGET_NAME)";
-                PROVISIONING_PROFILE_SPECIFIER = "";
-                SWIFT_VERSION = 5.0;
-                TARGETED_DEVICE_FAMILY = "1,2";
-            };
-            name = "Mainnet Release";
-        };
-        DDB660F92486BABB0060B0C5 /* Mainnet Debug */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ALWAYS_SEARCH_USER_PATHS = NO;
-                CLANG_ANALYZER_NONNULL = YES;
-                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-                CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-                CLANG_CXX_LIBRARY = "libc++";
-                CLANG_ENABLE_MODULES = YES;
-                CLANG_ENABLE_OBJC_ARC = YES;
-                CLANG_ENABLE_OBJC_WEAK = YES;
-                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-                CLANG_WARN_BOOL_CONVERSION = YES;
-                CLANG_WARN_COMMA = YES;
-                CLANG_WARN_CONSTANT_CONVERSION = YES;
-                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-                CLANG_WARN_EMPTY_BODY = YES;
-                CLANG_WARN_ENUM_CONVERSION = YES;
-                CLANG_WARN_INFINITE_RECURSION = YES;
-                CLANG_WARN_INT_CONVERSION = YES;
-                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-                CLANG_WARN_STRICT_PROTOTYPES = YES;
-                CLANG_WARN_SUSPICIOUS_MOVE = YES;
-                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-                CLANG_WARN_UNREACHABLE_CODE = YES;
-                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-                CODE_SIGN_STYLE = Automatic;
-                COPY_PHASE_STRIP = NO;
-                DEBUG_INFORMATION_FORMAT = dwarf;
-                DEVELOPMENT_TEAM = LYZ95J7356;
-                ENABLE_STRICT_OBJC_MSGSEND = YES;
-                ENABLE_TESTABILITY = YES;
-                GCC_C_LANGUAGE_STANDARD = gnu11;
-                GCC_DYNAMIC_NO_PIC = NO;
-                GCC_NO_COMMON_BLOCKS = YES;
-                GCC_OPTIMIZATION_LEVEL = 0;
-                GCC_PREPROCESSOR_DEFINITIONS = (
-                    "DEBUG=1",
-                    "$(inherited)",
-                );
-                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-                GCC_WARN_UNDECLARED_SELECTOR = YES;
-                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-                GCC_WARN_UNUSED_FUNCTION = YES;
-                GCC_WARN_UNUSED_VARIABLE = YES;
-                INFOPLIST_FILE = "Decred WalletUITests/Info.plist";
-                IPHONEOS_DEPLOYMENT_TARGET = 13.4;
-                LD_RUNPATH_SEARCH_PATHS = (
-                    "$(inherited)",
-                    "@executable_path/Frameworks",
-                    "@loader_path/Frameworks",
-                );
-                MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
-                MTL_FAST_MATH = YES;
-                ONLY_ACTIVE_ARCH = YES;
-                PRODUCT_BUNDLE_IDENTIFIER = "com.macsleven.Decred-WalletUITests";
-                PRODUCT_NAME = "$(TARGET_NAME)";
-                SDKROOT = iphoneos;
-                SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-                SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-                SWIFT_VERSION = 5.0;
-                TARGETED_DEVICE_FAMILY = "1,2";
-                TEST_TARGET_NAME = "Decred Wallet";
-            };
-            name = "Mainnet Debug";
-        };
-        DDB660FA2486BABB0060B0C5 /* Testnet Debug */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ALWAYS_SEARCH_USER_PATHS = NO;
-                CLANG_ANALYZER_NONNULL = YES;
-                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-                CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-                CLANG_CXX_LIBRARY = "libc++";
-                CLANG_ENABLE_MODULES = YES;
-                CLANG_ENABLE_OBJC_ARC = YES;
-                CLANG_ENABLE_OBJC_WEAK = YES;
-                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-                CLANG_WARN_BOOL_CONVERSION = YES;
-                CLANG_WARN_COMMA = YES;
-                CLANG_WARN_CONSTANT_CONVERSION = YES;
-                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-                CLANG_WARN_EMPTY_BODY = YES;
-                CLANG_WARN_ENUM_CONVERSION = YES;
-                CLANG_WARN_INFINITE_RECURSION = YES;
-                CLANG_WARN_INT_CONVERSION = YES;
-                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-                CLANG_WARN_STRICT_PROTOTYPES = YES;
-                CLANG_WARN_SUSPICIOUS_MOVE = YES;
-                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-                CLANG_WARN_UNREACHABLE_CODE = YES;
-                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-                CODE_SIGN_STYLE = Automatic;
-                COPY_PHASE_STRIP = NO;
-                DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-                DEVELOPMENT_TEAM = LYZ95J7356;
-                ENABLE_NS_ASSERTIONS = NO;
-                ENABLE_STRICT_OBJC_MSGSEND = YES;
-                GCC_C_LANGUAGE_STANDARD = gnu11;
-                GCC_NO_COMMON_BLOCKS = YES;
-                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-                GCC_WARN_UNDECLARED_SELECTOR = YES;
-                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-                GCC_WARN_UNUSED_FUNCTION = YES;
-                GCC_WARN_UNUSED_VARIABLE = YES;
-                INFOPLIST_FILE = "Decred WalletUITests/Info.plist";
-                IPHONEOS_DEPLOYMENT_TARGET = 13.4;
-                LD_RUNPATH_SEARCH_PATHS = (
-                    "$(inherited)",
-                    "@executable_path/Frameworks",
-                    "@loader_path/Frameworks",
-                );
-                MTL_ENABLE_DEBUG_INFO = NO;
-                MTL_FAST_MATH = YES;
-                PRODUCT_BUNDLE_IDENTIFIER = "com.macsleven.Decred-WalletUITests";
-                PRODUCT_NAME = "$(TARGET_NAME)";
-                SDKROOT = iphoneos;
-                SWIFT_COMPILATION_MODE = wholemodule;
-                SWIFT_OPTIMIZATION_LEVEL = "-O";
-                SWIFT_VERSION = 5.0;
-                TARGETED_DEVICE_FAMILY = "1,2";
-                TEST_TARGET_NAME = "Decred Wallet";
-                VALIDATE_PRODUCT = YES;
-            };
-            name = "Testnet Debug";
-        };
-        DDB660FB2486BABB0060B0C5 /* Mainnet Release */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ALWAYS_SEARCH_USER_PATHS = NO;
-                CLANG_ANALYZER_NONNULL = YES;
-                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-                CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-                CLANG_CXX_LIBRARY = "libc++";
-                CLANG_ENABLE_MODULES = YES;
-                CLANG_ENABLE_OBJC_ARC = YES;
-                CLANG_ENABLE_OBJC_WEAK = YES;
-                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-                CLANG_WARN_BOOL_CONVERSION = YES;
-                CLANG_WARN_COMMA = YES;
-                CLANG_WARN_CONSTANT_CONVERSION = YES;
-                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-                CLANG_WARN_EMPTY_BODY = YES;
-                CLANG_WARN_ENUM_CONVERSION = YES;
-                CLANG_WARN_INFINITE_RECURSION = YES;
-                CLANG_WARN_INT_CONVERSION = YES;
-                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-                CLANG_WARN_STRICT_PROTOTYPES = YES;
-                CLANG_WARN_SUSPICIOUS_MOVE = YES;
-                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-                CLANG_WARN_UNREACHABLE_CODE = YES;
-                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-                CODE_SIGN_STYLE = Automatic;
-                COPY_PHASE_STRIP = NO;
-                DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-                DEVELOPMENT_TEAM = LYZ95J7356;
-                ENABLE_NS_ASSERTIONS = NO;
-                ENABLE_STRICT_OBJC_MSGSEND = YES;
-                GCC_C_LANGUAGE_STANDARD = gnu11;
-                GCC_NO_COMMON_BLOCKS = YES;
-                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-                GCC_WARN_UNDECLARED_SELECTOR = YES;
-                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-                GCC_WARN_UNUSED_FUNCTION = YES;
-                GCC_WARN_UNUSED_VARIABLE = YES;
-                INFOPLIST_FILE = "Decred WalletUITests/Info.plist";
-                IPHONEOS_DEPLOYMENT_TARGET = 13.4;
-                LD_RUNPATH_SEARCH_PATHS = (
-                    "$(inherited)",
-                    "@executable_path/Frameworks",
-                    "@loader_path/Frameworks",
-                );
-                MTL_ENABLE_DEBUG_INFO = NO;
-                MTL_FAST_MATH = YES;
-                PRODUCT_BUNDLE_IDENTIFIER = "com.macsleven.Decred-WalletUITests";
-                PRODUCT_NAME = "$(TARGET_NAME)";
-                SDKROOT = iphoneos;
-                SWIFT_COMPILATION_MODE = wholemodule;
-                SWIFT_OPTIMIZATION_LEVEL = "-O";
-                SWIFT_VERSION = 5.0;
-                TARGETED_DEVICE_FAMILY = "1,2";
-                TEST_TARGET_NAME = "Decred Wallet";
-                VALIDATE_PRODUCT = YES;
-            };
-            name = "Mainnet Release";
-        };
-        DDB660FC2486BABB0060B0C5 /* Testnet Release */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ALWAYS_SEARCH_USER_PATHS = NO;
-                CLANG_ANALYZER_NONNULL = YES;
-                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-                CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-                CLANG_CXX_LIBRARY = "libc++";
-                CLANG_ENABLE_MODULES = YES;
-                CLANG_ENABLE_OBJC_ARC = YES;
-                CLANG_ENABLE_OBJC_WEAK = YES;
-                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-                CLANG_WARN_BOOL_CONVERSION = YES;
-                CLANG_WARN_COMMA = YES;
-                CLANG_WARN_CONSTANT_CONVERSION = YES;
-                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-                CLANG_WARN_EMPTY_BODY = YES;
-                CLANG_WARN_ENUM_CONVERSION = YES;
-                CLANG_WARN_INFINITE_RECURSION = YES;
-                CLANG_WARN_INT_CONVERSION = YES;
-                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-                CLANG_WARN_STRICT_PROTOTYPES = YES;
-                CLANG_WARN_SUSPICIOUS_MOVE = YES;
-                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-                CLANG_WARN_UNREACHABLE_CODE = YES;
-                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-                CODE_SIGN_STYLE = Automatic;
-                COPY_PHASE_STRIP = NO;
-                DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-                DEVELOPMENT_TEAM = LYZ95J7356;
-                ENABLE_NS_ASSERTIONS = NO;
-                ENABLE_STRICT_OBJC_MSGSEND = YES;
-                GCC_C_LANGUAGE_STANDARD = gnu11;
-                GCC_NO_COMMON_BLOCKS = YES;
-                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-                GCC_WARN_UNDECLARED_SELECTOR = YES;
-                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-                GCC_WARN_UNUSED_FUNCTION = YES;
-                GCC_WARN_UNUSED_VARIABLE = YES;
-                INFOPLIST_FILE = "Decred WalletUITests/Info.plist";
-                IPHONEOS_DEPLOYMENT_TARGET = 13.4;
-                LD_RUNPATH_SEARCH_PATHS = (
-                    "$(inherited)",
-                    "@executable_path/Frameworks",
-                    "@loader_path/Frameworks",
-                );
-                MTL_ENABLE_DEBUG_INFO = NO;
-                MTL_FAST_MATH = YES;
-                PRODUCT_BUNDLE_IDENTIFIER = "com.macsleven.Decred-WalletUITests";
-                PRODUCT_NAME = "$(TARGET_NAME)";
-                SDKROOT = iphoneos;
-                SWIFT_COMPILATION_MODE = wholemodule;
-                SWIFT_OPTIMIZATION_LEVEL = "-O";
-                SWIFT_VERSION = 5.0;
-                TARGETED_DEVICE_FAMILY = "1,2";
-                TEST_TARGET_NAME = "Decred Wallet";
-                VALIDATE_PRODUCT = YES;
-            };
-            name = "Testnet Release";
-        };
+		B30A37CC228F3AE100F78629 /* Testnet Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "-DIsTestnet";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = "Testnet Debug";
+		};
+		B30A37CD228F3AE100F78629 /* Testnet Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B107091A1D996651AB5D8891 /* Pods-Decred Wallet.testnet debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconTestnet;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = LYZ95J7356;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/libs",
+				);
+				INFOPLIST_FILE = "Decred Wallet/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.5.2;
+				PRODUCT_BUNDLE_IDENTIFIER = com.decred.dcrios.testnet3;
+				PRODUCT_NAME = "$(TARGET_NAME) Testnet";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Testnet Debug";
+		};
+		B30A37CE228F3AF000F78629 /* Testnet Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				OTHER_SWIFT_FLAGS = "-DIsTestnet";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = "Testnet Release";
+		};
+		B30A37CF228F3AF000F78629 /* Testnet Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D59C7DB99807D17630259A55 /* Pods-Decred Wallet.testnet release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconTestnet;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = LYZ95J7356;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/libs",
+				);
+				INFOPLIST_FILE = "Decred Wallet/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.5.2;
+				PRODUCT_BUNDLE_IDENTIFIER = com.decred.dcrios.testnet3;
+				PRODUCT_NAME = "$(TARGET_NAME) Testnet";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Testnet Release";
+		};
+		B3B4699F228F0C2E00A68EDD /* Mainnet Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = "Mainnet Debug";
+		};
+		B3B469A0228F0C2E00A68EDD /* Mainnet Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = "Mainnet Release";
+		};
+		B3B469A2228F0C2E00A68EDD /* Mainnet Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6A0625AB1C6ACD2EC77F544F /* Pods-Decred Wallet.mainnet debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = LYZ95J7356;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/libs",
+				);
+				INFOPLIST_FILE = "Decred Wallet/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.5.2;
+				PRODUCT_BUNDLE_IDENTIFIER = com.decred.dcrios.mainnet;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Mainnet Debug";
+		};
+		B3B469A3228F0C2E00A68EDD /* Mainnet Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 23F5A25CDDC0ADF47F98ED95 /* Pods-Decred Wallet.mainnet release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 2K5T5F7P2C;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/libs",
+				);
+				INFOPLIST_FILE = "Decred Wallet/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.5.2;
+				PRODUCT_BUNDLE_IDENTIFIER = com.decred.dcrios.mainnet;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Mainnet Release";
+		};
+		DDB660F92486BABB0060B0C5 /* Mainnet Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = LYZ95J7356;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "Decred WalletUITests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.macsleven.Decred-WalletUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "Decred Wallet";
+			};
+			name = "Mainnet Debug";
+		};
+		DDB660FA2486BABB0060B0C5 /* Testnet Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = LYZ95J7356;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "Decred WalletUITests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.macsleven.Decred-WalletUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "Decred Wallet";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = "Testnet Debug";
+		};
+		DDB660FB2486BABB0060B0C5 /* Mainnet Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = LYZ95J7356;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "Decred WalletUITests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.macsleven.Decred-WalletUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "Decred Wallet";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = "Mainnet Release";
+		};
+		DDB660FC2486BABB0060B0C5 /* Testnet Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = LYZ95J7356;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "Decred WalletUITests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.macsleven.Decred-WalletUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "Decred Wallet";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = "Testnet Release";
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-        B3B4698A228F0C2D00A68EDD /* Build configuration list for PBXProject "Decred Wallet" */ = {
-            isa = XCConfigurationList;
-            buildConfigurations = (
-                B3B4699F228F0C2E00A68EDD /* Mainnet Debug */,
-                B30A37CC228F3AE100F78629 /* Testnet Debug */,
-                B3B469A0228F0C2E00A68EDD /* Mainnet Release */,
-                B30A37CE228F3AF000F78629 /* Testnet Release */,
-            );
-            defaultConfigurationIsVisible = 0;
-            defaultConfigurationName = "Mainnet Release";
-        };
-        B3B469A1228F0C2E00A68EDD /* Build configuration list for PBXNativeTarget "Decred Wallet" */ = {
-            isa = XCConfigurationList;
-            buildConfigurations = (
-                B3B469A2228F0C2E00A68EDD /* Mainnet Debug */,
-                B30A37CD228F3AE100F78629 /* Testnet Debug */,
-                B3B469A3228F0C2E00A68EDD /* Mainnet Release */,
-                B30A37CF228F3AF000F78629 /* Testnet Release */,
-            );
-            defaultConfigurationIsVisible = 0;
-            defaultConfigurationName = "Mainnet Release";
-        };
-        DDB660FD2486BABB0060B0C5 /* Build configuration list for PBXNativeTarget "Decred WalletUITests" */ = {
-            isa = XCConfigurationList;
-            buildConfigurations = (
-                DDB660F92486BABB0060B0C5 /* Mainnet Debug */,
-                DDB660FA2486BABB0060B0C5 /* Testnet Debug */,
-                DDB660FB2486BABB0060B0C5 /* Mainnet Release */,
-                DDB660FC2486BABB0060B0C5 /* Testnet Release */,
-            );
-            defaultConfigurationIsVisible = 0;
-            defaultConfigurationName = "Mainnet Release";
-        };
+		B3B4698A228F0C2D00A68EDD /* Build configuration list for PBXProject "Decred Wallet" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B3B4699F228F0C2E00A68EDD /* Mainnet Debug */,
+				B30A37CC228F3AE100F78629 /* Testnet Debug */,
+				B3B469A0228F0C2E00A68EDD /* Mainnet Release */,
+				B30A37CE228F3AF000F78629 /* Testnet Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Mainnet Release";
+		};
+		B3B469A1228F0C2E00A68EDD /* Build configuration list for PBXNativeTarget "Decred Wallet" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B3B469A2228F0C2E00A68EDD /* Mainnet Debug */,
+				B30A37CD228F3AE100F78629 /* Testnet Debug */,
+				B3B469A3228F0C2E00A68EDD /* Mainnet Release */,
+				B30A37CF228F3AF000F78629 /* Testnet Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Mainnet Release";
+		};
+		DDB660FD2486BABB0060B0C5 /* Build configuration list for PBXNativeTarget "Decred WalletUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DDB660F92486BABB0060B0C5 /* Mainnet Debug */,
+				DDB660FA2486BABB0060B0C5 /* Testnet Debug */,
+				DDB660FB2486BABB0060B0C5 /* Mainnet Release */,
+				DDB660FC2486BABB0060B0C5 /* Testnet Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Mainnet Release";
+		};
 /* End XCConfigurationList section */
-    };
-    rootObject = B3B46987228F0C2D00A68EDD /* Project object */;
+	};
+	rootObject = B3B46987228F0C2D00A68EDD /* Project object */;
 }

--- a/Decred Wallet.xcodeproj/project.pbxproj
+++ b/Decred Wallet.xcodeproj/project.pbxproj
@@ -1544,7 +1544,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconTestnet;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = LYZ95J7356;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1629,7 +1629,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconTestnet;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = LYZ95J7356;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1776,7 +1776,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = LYZ95J7356;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Decred Wallet.xcodeproj/xcshareddata/xcschemes/Decred Wallet Testnet.xcscheme
+++ b/Decred Wallet.xcodeproj/xcshareddata/xcschemes/Decred Wallet Testnet.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Decred Wallet.xcodeproj/xcshareddata/xcschemes/Decred Wallet.xcscheme
+++ b/Decred Wallet.xcodeproj/xcshareddata/xcschemes/Decred Wallet.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Decred Wallet/Custom Views/WalletAccountView/WalletAccountView.swift
+++ b/Decred Wallet/Custom Views/WalletAccountView/WalletAccountView.swift
@@ -35,6 +35,7 @@ import Dcrlibwallet
     var showWatchOnlyWallet = true
     var showMixedAccount = true
     var showUnMixedAccount = true
+    var showMixedOnly = true
     
     var onAccountSelectionChanged: ((_ selectedWallet: DcrlibwalletWallet, _ selectedAccount: DcrlibwalletAccount) -> Void)?
     
@@ -81,7 +82,7 @@ import Dcrlibwallet
                                    selectedWallet: self.selectedWallet,
                                    selectedAccount: self.selectedAccount, showWatchOnlyWallet: showWatchOnlyWallet,
                                    showUnMixedAccount: showUnMixedAccount,
-                                   showMixedAccount: showMixedAccount,
+                                   showMixedAccount: showMixedAccount, showMixedOnly: showMixedOnly,
                                    callback: self.updateSelectedAccount)
     }
 
@@ -103,5 +104,38 @@ import Dcrlibwallet
         self.selectedAccount = firstWalletAccount
         
         self.onAccountSelectionChanged?(firstWallet, firstWalletAccount)
+    }
+    
+    func selectFirstFilterWalletAccount() {
+        guard let firstWallet = WalletLoader.shared.wallets.first,
+            let firstWalletAccount = firstWallet.accounts.filter({ $0.totalBalance > 0 || $0.name != "imported" }).first,
+            let firstWalletUnMixedAccount = firstWallet.accounts.filter({ $0.totalBalance > 0 || $0.name != "imported" && $0.number != firstWallet.readInt32ConfigValue(forKey: DcrlibwalletAccountMixerUnmixedAccount, defaultValue: -1)}).first,
+            let firstWalletMixedOnlyAccount = firstWallet.accounts.filter({$0.number == firstWallet.readInt32ConfigValue(forKey: DcrlibwalletAccountMixerMixedAccount, defaultValue: -1)}).first,
+            let firstWalletMixedAccount = firstWallet.accounts.filter({ $0.totalBalance > 0 || $0.name != "imported" && $0.number != firstWallet.readInt32ConfigValue(forKey: DcrlibwalletAccountMixerMixedAccount, defaultValue: -1)}).first
+        else { return }
+        self.selectedWallet = firstWallet
+        if !showUnMixedAccount {
+            self.selectedAccount = firstWalletUnMixedAccount
+            self.onAccountSelectionChanged?(firstWallet, firstWalletUnMixedAccount)
+            return
+        }
+        
+        if !showMixedOnly {
+            self.selectedAccount = firstWalletMixedOnlyAccount
+            self.onAccountSelectionChanged?(firstWallet, firstWalletMixedOnlyAccount)
+            return
+        }
+        
+        if !showMixedAccount {
+            self.selectedAccount = firstWalletMixedAccount
+            self.onAccountSelectionChanged?(firstWallet, firstWalletMixedAccount)
+            return
+        }
+        
+        self.selectedAccount = firstWalletAccount
+        
+        
+        self.onAccountSelectionChanged?(firstWallet, firstWalletAccount)
+        
     }
 }

--- a/Decred Wallet/DcrlibwalletTypes/Wallet.swift
+++ b/Decred Wallet/DcrlibwalletTypes/Wallet.swift
@@ -18,9 +18,12 @@ class Wallet: NSObject {
     private(set) var displayAccounts: Bool = false
     private(set) var isAccountMixerActive: Bool = false
     
-    private var accountsFilterFn: ((DcrlibwalletAccount) -> Bool)?
+    typealias AccountFilter = (DcrlibwalletAccount)  -> Bool
+    private var accountsFilterFn: AccountFilter = {_ in
+        return true //all accounts are shown by default
+    }
     
-    init(_ wallet: DcrlibwalletWallet, accountsFilterFn: ((DcrlibwalletAccount) -> Bool)? = nil) {
+    init(_ wallet: DcrlibwalletWallet, accountsFilterFn: AccountFilter? = nil) {
         self.id = wallet.id_
         self.name = wallet.name
         self.balance = "\((Decimal(wallet.totalWalletBalance) as NSDecimalNumber).round(8)) DCR"
@@ -29,9 +32,9 @@ class Wallet: NSObject {
         self.displayAccounts = false
         self.isAccountMixerActive = wallet.isAccountMixerActive()
 
-        self.accountsFilterFn = accountsFilterFn
         if accountsFilterFn != nil {
-            self.accounts = self.accounts.filter(accountsFilterFn!)
+            self.accountsFilterFn = accountsFilterFn!
+            self.accounts = self.accounts.filter(self.accountsFilterFn)
         }
     }
     
@@ -43,10 +46,7 @@ class Wallet: NSObject {
         guard let wallet = WalletLoader.shared.multiWallet.wallet(withID: self.id) else {
             return
         }
-        
-        self.accounts = wallet.accounts
-        if self.accountsFilterFn != nil {
-            self.accounts = self.accounts.filter(self.accountsFilterFn!)
-        }
+
+        self.accounts = wallet.accounts.filter(self.accountsFilterFn)
     }
 }

--- a/Decred Wallet/Extensions/Dcrlibwallet.swift
+++ b/Decred Wallet/Extensions/Dcrlibwallet.swift
@@ -84,6 +84,16 @@ extension DcrlibwalletAccount {
         return false
     }
     
+    var isMixerMixedAccount: Bool {
+        let wallet = WalletLoader.shared.multiWallet!.wallet(withID: self.walletID)!
+        return wallet.readInt32ConfigValue(forKey: DcrlibwalletAccountMixerMixedAccount, defaultValue: -1) == number
+    }
+    
+    var isMixerUnmixedAccount: Bool {
+        let wallet = WalletLoader.shared.multiWallet!.wallet(withID: self.walletID)!
+        return wallet.readInt32ConfigValue(forKey: DcrlibwalletAccountMixerUnmixedAccount, defaultValue: -1) == number
+    }
+    
     var dcrTotalBalance: Double {
         return DcrlibwalletAmountCoin(self.totalBalance)
     }

--- a/Decred Wallet/Features/Custom Dialogs/AccountSelectorDialog/AccountSelectorDialog.swift
+++ b/Decred Wallet/Features/Custom Dialogs/AccountSelectorDialog/AccountSelectorDialog.swift
@@ -25,6 +25,7 @@ class AccountSelectorDialog: UIViewController {
     var showWatchOnly = true
     var showUnMixedAccount = true
     var showMixedAccount = true
+    var showMixedOnly = true
 
     let accountCellRowHeight: CGFloat = 74
     let walletHeaderSectionHeight: CGFloat = 36
@@ -36,6 +37,7 @@ class AccountSelectorDialog: UIViewController {
                      showWatchOnlyWallet: Bool,
                      showUnMixedAccount: Bool,
                      showMixedAccount: Bool,
+                     showMixedOnly: Bool,
                      callback: @escaping AccountSelectorDialogCallback) {
 
         let dialog = AccountSelectorDialog.instantiate(from: .CustomDialogs)
@@ -45,6 +47,7 @@ class AccountSelectorDialog: UIViewController {
         dialog.selectedAccount = selectedAccount
         dialog.showWatchOnly = showWatchOnlyWallet
         dialog.showUnMixedAccount = showUnMixedAccount
+        dialog.showMixedOnly = showMixedOnly
         dialog.showMixedAccount = showMixedAccount
         dialog.modalPresentationStyle = .pageSheet
         vc.present(dialog, animated: true, completion: nil)
@@ -73,6 +76,10 @@ class AccountSelectorDialog: UIViewController {
         var accountsFilterFn: (DcrlibwalletAccount) -> Bool = { $0.totalBalance > 0 || $0.name != "imported" }
         if !showUnMixedAccount {
             accountsFilterFn = { $0.totalBalance > 0 || $0.name != "imported" && $0.number != self.selectedWallet?.readInt32ConfigValue(forKey: DcrlibwalletAccountMixerUnmixedAccount, defaultValue: -1)}
+        }
+        
+        if !showMixedOnly {
+            accountsFilterFn = {$0.number == self.selectedWallet?.readInt32ConfigValue(forKey: DcrlibwalletAccountMixerMixedAccount, defaultValue: -1)}
         }
         
         if !showMixedAccount {

--- a/Decred Wallet/Features/Custom Dialogs/AccountSelectorDialog/AccountSelectorDialog.swift
+++ b/Decred Wallet/Features/Custom Dialogs/AccountSelectorDialog/AccountSelectorDialog.swift
@@ -83,7 +83,7 @@ class AccountSelectorDialog: UIViewController {
         }
         
         if !showMixedAccount {
-            accountsFilterFn = { $0.totalBalance > 0 || $0.name != "imported" && $0.number != self.selectedWallet?.readInt32ConfigValue(forKey: DcrlibwalletAccountMixerMixedAccount, defaultValue: -1)}
+            accountsFilterFn = { $0.name != "imported" && $0.number != self.selectedWallet?.readInt32ConfigValue(forKey: DcrlibwalletAccountMixerMixedAccount, defaultValue: -1)}
         }
 
         let fullCoinWallet = WalletLoader.shared.wallets.filter { !$0.isWatchingOnlyWallet()}

--- a/Decred Wallet/Features/Privacy/Privacy.storyboard
+++ b/Decred Wallet/Features/Privacy/Privacy.storyboard
@@ -1272,6 +1272,7 @@
                         <outlet property="unMixedAccountView" destination="piF-wJ-hQd" id="366-kG-hiI"/>
                         <outlet property="unMixedHeight" destination="hCh-c7-Ay2" id="9iH-qR-qhi"/>
                         <outlet property="unmixedAccountViewCont" destination="op5-gv-ZUw" id="p9v-zz-WOH"/>
+                        <outlet property="walletNameLabel" destination="Wov-X4-mJT" id="aop-BB-YTt"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="WOV-Dh-Q8c" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Decred Wallet/Features/Privacy/PrivacyManualSetupViewController.swift
+++ b/Decred Wallet/Features/Privacy/PrivacyManualSetupViewController.swift
@@ -11,7 +11,7 @@ import Dcrlibwallet
 
 class PrivacyManualSetupViewController: UIViewController {
     
-    var wallet: DcrlibwalletWallet!
+    @IBOutlet weak var walletNameLabel: UILabel!
     @IBOutlet weak var mixedAccountView: WalletAccountView!
     @IBOutlet weak var unMixedAccountView: WalletAccountView!
     @IBOutlet weak var unmixedAccountViewCont: RoundedView!
@@ -21,6 +21,8 @@ class PrivacyManualSetupViewController: UIViewController {
     @IBOutlet weak var mixedHeight: NSLayoutConstraint!
     
     @IBOutlet weak var manualSetupWaningLabel: UILabel!
+    
+    var wallet: DcrlibwalletWallet!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -50,12 +52,12 @@ class PrivacyManualSetupViewController: UIViewController {
     }
     
     func setupViews() {
+        
+        self.walletNameLabel.text = wallet.name
+        
         self.mixedAccountView.accountBalanceLabel.isHidden = true
         self.unMixedAccountView.accountBalanceLabel.isHidden = true
-        
-        self.mixedAccountView.showWatchOnlyWallet = false
-        self.unMixedAccountView.showWatchOnlyWallet = false
-        
+
         self.unMixedAccountView.walletNameLabel.isHidden = true
         self.mixedAccountView.walletNameLabel.isHidden = true
         
@@ -82,11 +84,22 @@ class PrivacyManualSetupViewController: UIViewController {
         self.mixedHeight.constant = 90
         self.mixedAccountView.layoutSubviews()
         
-        self.mixedAccountView.selectFirstWalletAccount()
-        self.unMixedAccountView.selectFirstWalletAccount()
+        let accountFilterFn: Wallet.AccountFilter = {account in
+            // remove other wallet accounts and imported account
+            if account.walletID != self.wallet.id_ || account.number == Int32.max {
+                return false
+            }
+            return true
+        }
         
-        self.mixedAccountView.onAccountSelectionChanged = { _, newSourceAccount in}
-        self.unMixedAccountView.onAccountSelectionChanged = { _, newSourceAccount in}
+        self.mixedAccountView.accountFilterFn = accountFilterFn
+        self.unMixedAccountView.accountFilterFn = accountFilterFn
+        
+        self.mixedAccountView.selectFirstValidWalletAccount()
+        self.unMixedAccountView.selectFirstValidWalletAccount()
+        
+        self.mixedAccountView.onAccountSelectionChanged = { newSourceAccount in}
+        self.unMixedAccountView.onAccountSelectionChanged = { newSourceAccount in}
     }
     
     func AuthMixerAccount() {

--- a/Decred Wallet/Features/Send/SendViewController.swift
+++ b/Decred Wallet/Features/Send/SendViewController.swift
@@ -273,6 +273,7 @@ class SendViewController: UIViewController {
             self.sourceAccountView.showMixedAccount = self.toAddressSection.isHidden
             self.sourceAccountView.showUnMixedAccount = self.toAddressSection.isHidden
             self.sourceAccountView.showMixedOnly = true
+            self.destinationAccountView.showMixedAccount = false
             self.sourceAccountView.selectFirstFilterWalletAccount()
             self.displayFeeDetailsAndTransactionSummary() // re-calculate fee with updated destination info
         })

--- a/Decred Wallet/Features/TransactionDetails/TransactionDetailsViewController.swift
+++ b/Decred Wallet/Features/TransactionDetails/TransactionDetailsViewController.swift
@@ -71,12 +71,16 @@ class TransactionDetailsViewController: UIViewController {
 
     private func displayTitle() {
         if self.transaction.type == DcrlibwalletTxTypeRegular {
-            if self.transaction.direction == DcrlibwalletTxDirectionSent {
-                self.txTypeLabel.text = LocalizedStrings.sent
-            } else if self.transaction.direction == DcrlibwalletTxDirectionReceived {
-                self.txTypeLabel.text = LocalizedStrings.received
-            } else if self.transaction.direction == DcrlibwalletTxDirectionTransferred {
-                self.txTypeLabel.text = LocalizedStrings.transferred
+            if transaction.isMixed {
+                self.txTypeLabel.text = LocalizedStrings.mixed
+            } else {
+                if self.transaction.direction == DcrlibwalletTxDirectionSent {
+                    self.txTypeLabel.text = LocalizedStrings.sent
+                } else if self.transaction.direction == DcrlibwalletTxDirectionReceived {
+                    self.txTypeLabel.text = LocalizedStrings.received
+                } else if self.transaction.direction == DcrlibwalletTxDirectionTransferred {
+                    self.txTypeLabel.text = LocalizedStrings.transferred
+                }
             }
         } else if self.transaction.type == DcrlibwalletTxTypeVote {
             self.txTypeLabel.text = LocalizedStrings.voted

--- a/Decred Wallet/Features/TransactionDetails/TransactionDetailsViewController.swift
+++ b/Decred Wallet/Features/TransactionDetails/TransactionDetailsViewController.swift
@@ -224,7 +224,7 @@ class TransactionDetailsViewController: UIViewController {
         } else if transaction.direction == DcrlibwalletTxDirectionReceived {
             self.txOverview.txIconImage = UIImage(named: "ic_receive")
         } else if transaction.direction == DcrlibwalletTxDirectionTransferred {
-            self.txOverview.txIconImage = UIImage(named: "ic_fee")
+            self.txOverview.txIconImage = UIImage(named: "nav_menu/ic_wallet")
         }
     }
 

--- a/Decred Wallet/es.lproj/Localizable.strings
+++ b/Decred Wallet/es.lproj/Localizable.strings
@@ -583,3 +583,4 @@
 "continueText" = "Continue";
 "unlockToStartMixing" = "Unlock your wallet to start mixing";
 "mixed" = "Mixed";
+"mix" = "Mix";

--- a/Decred Wallet/fr.lproj/Localizable.strings
+++ b/Decred Wallet/fr.lproj/Localizable.strings
@@ -583,3 +583,4 @@
 "continueText" = "Continue";
 "unlockToStartMixing" = "Unlock your wallet to start mixing";
 "mixed" = "Mixed";
+"mix" = "Mix";

--- a/Decred Wallet/pl.lproj/Localizable.strings
+++ b/Decred Wallet/pl.lproj/Localizable.strings
@@ -583,3 +583,4 @@
 "continueText" = "Continue";
 "unlockToStartMixing" = "Unlock your wallet to start mixing";
 "mixed" = "Mixed";
+"mix" = "Mix";

--- a/Decred Wallet/pt-BR.lproj/Localizable.strings
+++ b/Decred Wallet/pt-BR.lproj/Localizable.strings
@@ -583,3 +583,4 @@
 "continueText" = "Continue";
 "unlockToStartMixing" = "Unlock your wallet to start mixing";
 "mixed" = "Mixed";
+"mix" = "Mix";

--- a/Decred Wallet/ru-RU.lproj/Localizable.strings
+++ b/Decred Wallet/ru-RU.lproj/Localizable.strings
@@ -583,3 +583,4 @@
 "continueText" = "Continue";
 "unlockToStartMixing" = "Unlock your wallet to start mixing";
 "mixed" = "Mixed";
+"mix" = "Mix";

--- a/Decred Wallet/vi.lproj/Localizable.strings
+++ b/Decred Wallet/vi.lproj/Localizable.strings
@@ -583,3 +583,4 @@
 "continueText" = "Continue";
 "unlockToStartMixing" = "Unlock your wallet to start mixing";
 "mixed" = "Mixed";
+"mix" = "Mix";

--- a/Decred Wallet/zh-Hans.lproj/Localizable.strings
+++ b/Decred Wallet/zh-Hans.lproj/Localizable.strings
@@ -583,3 +583,4 @@
 "continueText" = "Continue";
 "unlockToStartMixing" = "Unlock your wallet to start mixing";
 "mixed" = "Mixed";
+"mix" = "Mix";


### PR DESCRIPTION
This PR implements the appropriate account to display on the send view for both privacy wallet and non privacy wallet.

- Also Implements support for iOS 11
closes #758 

<img height="500" alt="Screenshot 2021-05-20 at 01 42 09" src="https://user-images.githubusercontent.com/794430/118902053-bad1f480-b90c-11eb-8d24-2530b8f78c0b.png">
<img height="500" alt="Screenshot 2021-05-20 at 01 42 30" src="https://user-images.githubusercontent.com/794430/118902057-bc032180-b90c-11eb-8d16-6fb081feb9d4.png">
<img height="500" alt="Screenshot 2021-05-20 at 01 42 44" src="https://user-images.githubusercontent.com/794430/118902062-be657b80-b90c-11eb-9db7-781ce89dd4e4.png">
