### PR TITLE
verify current password immediately after inputting it

### DIFF
--- a/Decred Wallet/Features/Wallets/WalletSettingsViewController.swift
+++ b/Decred Wallet/Features/Wallets/WalletSettingsViewController.swift
@@ -41,7 +41,7 @@ class WalletSettingsViewController: UIViewController {
     }
     
     @IBAction func changeSpendingPINPassword(_ sender: Any) {
-        SpendingPinOrPassword.change(sender: self, walletID: self.wallet.id_) {
+        SpendingPinOrPassword.begin(sender: self, walletID: self.wallet.id_) {
             Utils.showBanner(in: self.view, type: .success, text: LocalizedStrings.spendingPinPassChanged)
         }
     }

--- a/Decred Wallet/Wallet Utils/SpendingPinOrPassword.swift
+++ b/Decred Wallet/Wallet Utils/SpendingPinOrPassword.swift
@@ -14,22 +14,44 @@ struct SpendingPinOrPassword {
         Security.spending(initialSecurityType: SpendingPinOrPassword.securityType(for: walletID))
             .with(prompt: LocalizedStrings.confirmToChange)
             .with(submitBtnText: LocalizedStrings.confirm)
-            .requestCurrentAndNewCode(sender: sender) {
-                currentCode, currentCodeRequestDelegate, newCode, newCodeRequestDelegate, newCodeType in
+            .requestCurrentCode(sender: sender) {
+                currentCode, securityType, currentCodeRequestDelegate in
                 
-                self.changeWalletSpendingPassphrase(walletID: walletID,
+                self.verifyWalletSpendingPassphrase(walletID: walletID,
                                                     currentCode: currentCode,
                                                     currentCodeRequestDelegate: currentCodeRequestDelegate,
-                                                    newCode: newCode,
-                                                    newCodeRequestDelegate: newCodeRequestDelegate,
-                                                    newCodeType: newCodeType,
+                                                    securityType: securityType,
                                                     done: done)
+        }
+    }
+    
+    private static func verifyWalletSpendingPassphrase(walletID: Int,
+                                                       currentCode: String,
+                                                       currentCodeRequestDelegate: InputDialogDelegate?,
+                                                       securityType: SecurityType,
+                                                       done: (() -> ())?) {
+        
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let wallet = WalletLoader.shared.multiWallet.wallet(withID: walletID)
+                try wallet?.unlock(currentCode.utf8Bits)
+                wallet?.lock()
+                DispatchQueue.main.async {
+                    currentCodeRequestDelegate?.dismissDialog()
+                    done?()
+                }
+            } catch let error {
+                DispatchQueue.main.async {
+                    if error.isInvalidPassphraseError {
+                        currentCodeRequestDelegate?.displayPassphraseError(errorMessage: self.invalidSecurityCodeMessage(for: walletID))
+                    }
+                }
+            }
         }
     }
     
     private static func changeWalletSpendingPassphrase(walletID: Int,
                                                        currentCode: String,
-                                                       currentCodeRequestDelegate: InputDialogDelegate?,
                                                        newCode: String,
                                                        newCodeRequestDelegate: InputDialogDelegate?,
                                                        newCodeType: SecurityType,
@@ -44,14 +66,13 @@ struct SpendingPinOrPassword {
                 
                 DispatchQueue.main.async {
                     newCodeRequestDelegate?.dismissDialog()
-                    currentCodeRequestDelegate?.dismissDialog()
                     done?()
                 }
             } catch let error {
                 DispatchQueue.main.async {
                     if error.isInvalidPassphraseError {
                         newCodeRequestDelegate?.dismissDialog()
-                        currentCodeRequestDelegate?.displayPassphraseError(errorMessage: self.invalidSecurityCodeMessage(for: walletID))
+//                        currentCodeRequestDelegate?.displayPassphraseError(errorMessage: self.invalidSecurityCodeMessage(for: walletID))
                     } else {
                         newCodeRequestDelegate?.displayError(errorMessage: error.localizedDescription)
                     }
@@ -59,6 +80,39 @@ struct SpendingPinOrPassword {
             }
         }
     }
+    
+//    private static func changeWalletSpendingPassphrase(walletID: Int,
+//                                                       currentCode: String,
+//                                                       currentCodeRequestDelegate: InputDialogDelegate?,
+//                                                       newCode: String,
+//                                                       newCodeRequestDelegate: InputDialogDelegate?,
+//                                                       newCodeType: SecurityType,
+//                                                       done: (() -> ())?) {
+//
+//        DispatchQueue.global(qos: .userInitiated).async {
+//            do {
+//                try WalletLoader.shared.multiWallet.changePrivatePassphrase(forWallet: walletID,
+//                                                                            oldPrivatePassphrase: currentCode.utf8Bits,
+//                                                                            newPrivatePassphrase: newCode.utf8Bits,
+//                                                                            privatePassphraseType: newCodeType.type)
+//
+//                DispatchQueue.main.async {
+//                    newCodeRequestDelegate?.dismissDialog()
+//                    currentCodeRequestDelegate?.dismissDialog()
+//                    done?()
+//                }
+//            } catch let error {
+//                DispatchQueue.main.async {
+//                    if error.isInvalidPassphraseError {
+//                        newCodeRequestDelegate?.dismissDialog()
+//                        currentCodeRequestDelegate?.displayPassphraseError(errorMessage: self.invalidSecurityCodeMessage(for: walletID))
+//                    } else {
+//                        newCodeRequestDelegate?.displayError(errorMessage: error.localizedDescription)
+//                    }
+//                }
+//            }
+//        }
+//    }
     
     static func securityType(for walletID: Int) -> SecurityType {
         if let wallet = WalletLoader.shared.multiWallet.wallet(withID: walletID) {


### PR DESCRIPTION
Resolves #705 

This PR checks to verify if the users's current password/pin is correct, before showing the dialog to enter a new password/pin while changing the (startup password/PIN) and  (spending password/PIN)