### PR TITLE
format politeia details description (no UIWebview)

### DIFF
--- a/Decred Wallet/Features/More/More Features/Politeia/PoliteiaDetailController.swift
+++ b/Decred Wallet/Features/More/More Features/Politeia/PoliteiaDetailController.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import UIKit
+import Down
 
 class PoliteiaDetailController: UIViewController {
     @IBOutlet weak var titleLabel: UILabel!
@@ -140,7 +141,9 @@ class PoliteiaDetailController: UIViewController {
         }
         
         if politeia.indexfile != "" && politeia.fileversion == politeia.version {
-            self.contentTextView.text = politeia.indexfile
+            let down = Down(markdownString: politeia.indexfile)
+            let attributedString = try? down.toAttributedString()
+            self.contentTextView.attributedText = attributedString
         } else {
             self.contentLoadingIndicator.isHidden = false
             DispatchQueue.global(qos: .userInitiated).async {
@@ -151,7 +154,9 @@ class PoliteiaDetailController: UIViewController {
                     if error != nil {
                         self.contentTextView.text = error?.localizedDescription
                     } else {
-                        self.contentTextView.text = description
+                        let down = Down(markdownString: description!)
+                        let attributedString = try? down.toAttributedString()
+                        self.contentTextView.attributedText = attributedString
                     }
                 }
             }

--- a/Podfile
+++ b/Podfile
@@ -7,5 +7,6 @@ target 'Decred Wallet' do
 
   pod 'JGProgressHUD'
   pod 'QRCodeReader.swift'
+  pod 'Down'
 
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,20 +1,24 @@
 PODS:
+  - Down (0.11.0)
   - JGProgressHUD (2.2)
   - QRCodeReader.swift (10.1.0)
 
 DEPENDENCIES:
+  - Down
   - JGProgressHUD
   - QRCodeReader.swift
 
 SPEC REPOS:
   trunk:
+    - Down
     - JGProgressHUD
     - QRCodeReader.swift
 
 SPEC CHECKSUMS:
+  Down: b6ba1bc985c9d2f4e15e3b293d2207766fa12612
   JGProgressHUD: d83d7a981b85d11205e19ff8ad5bb9c40571c847
   QRCodeReader.swift: 373a389fe9a22d513c879a32a6f647c58f4ef572
 
-PODFILE CHECKSUM: 64169a56707a1ecbb7c4d47f0d73f353f9e24ba6
+PODFILE CHECKSUM: 9b9ccdaabb19ede54b35393bb86595cf157fece5
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
Resolves #768 

This PR adds basic rich text formatting without webview to the politeia description using a third party library (https://github.com/johnxnguyen/Down)

**Screenshots**
<img src="https://user-images.githubusercontent.com/25265396/120077829-34ec4100-c0a4-11eb-8e5f-c09b3b3f947c.png" width="300" />

**Limitations**

Table formatting is not supported. 

**Screenshots**
<img src="https://user-images.githubusercontent.com/25265396/120077865-6e24b100-c0a4-11eb-9a16-e85ddd42bae5.png" width="300" />