### PR TITLE
Add wallet name badge to overview transaction row 

### DIFF
--- a/Decred Wallet/Features/Overview/OverviewViewController.swift
+++ b/Decred Wallet/Features/Overview/OverviewViewController.swift
@@ -109,15 +109,15 @@ class OverviewViewController: UIViewController {
         // If sync is not ongoing, registering this listener enables us to get notified when a peer
         // is connected or disconnected, so we can update the peer count label appropriately.
         let syncProgressListener = self as DcrlibwalletSyncProgressListenerProtocol
-        try? WalletLoader.shared.multiWallet.add(syncProgressListener, uniqueIdentifier: "\(self)")
+        try? multiWallet.add(syncProgressListener, uniqueIdentifier: "\(self)")
         
         // Register tx notification listener to update recent activity table for new txs.
         let txNotificationListener = self as DcrlibwalletTxAndBlockNotificationListenerProtocol
-        try? WalletLoader.shared.multiWallet.add(txNotificationListener, uniqueIdentifier: "\(self)")
+        try? multiWallet.add(txNotificationListener, uniqueIdentifier: "\(self)")
         
-        WalletLoader.shared.multiWallet.setBlocksRescanProgressListener(self)
+        multiWallet.setBlocksRescanProgressListener(self)
         
-        WalletLoader.shared.multiWallet.setAccountMixerNotification(self)
+        multiWallet.setAccountMixerNotification(self)
 
         // Display latest block and connected peer count if there's no ongoing sync.
         if !SyncManager.shared.isSyncing {
@@ -134,7 +134,7 @@ class OverviewViewController: UIViewController {
         self.checkWhetherToPromptForSeedBackup()
         self.checkWhetherToPromptForAccountMixing()
         
-        if !WalletLoader.shared.multiWallet.isSyncing() {
+        if !multiWallet.isSyncing() {
             self.refreshLatestBlockInfoPeriodically()
         }
         
@@ -171,7 +171,7 @@ class OverviewViewController: UIViewController {
         
         self.exchangeRate = newExchangeRate ?? self.exchangeRate // maintain current value if new value is nil
 
-        let dcrAmount = WalletLoader.shared.multiWallet.totalBalance
+        let dcrAmount = multiWallet.totalBalance
         let usdAmount = NSDecimalNumber(value: dcrAmount).multiplying(by: exchangeRate!)
         self.exchangeValue = usdAmount
         self.usdBalanceLabel.isHidden = false
@@ -222,7 +222,7 @@ class OverviewViewController: UIViewController {
     }
     
     func updateMultiWalletBalance() {
-        let totalWalletAmount = WalletLoader.shared.multiWallet.totalBalance
+        let totalWalletAmount = multiWallet.totalBalance
         let totalAmountRoundedOff = (Decimal(totalWalletAmount) as NSDecimalNumber).round(8)
         self.balanceLabel.attributedText = Utils.getAttributedString(str: "\(totalAmountRoundedOff)", siz: 17.0, TexthexColor: UIColor.appColors.darkBlue)
         self.setMixerStatus()
@@ -230,7 +230,7 @@ class OverviewViewController: UIViewController {
     
     func updateRecentActivity() {
         // Fetch 3 most recent transactions
-        guard let transactions = WalletLoader.shared.multiWallet.transactionHistory(offset: 0, count: 3),
+        guard let transactions = multiWallet.transactionHistory(offset: 0, count: 3),
             !transactions.isEmpty
             else {
                 self.recentTransactionsTableView.isHidden = true
@@ -286,7 +286,7 @@ class OverviewViewController: UIViewController {
 
         // show appropriate view section depending on how many wallets are being synced
         if isSyncing {
-            let nOpenedWallets = WalletLoader.shared.multiWallet.openedWalletsCount()
+            let nOpenedWallets = multiWallet.openedWalletsCount()
             let isMultipleWalletsSync = nOpenedWallets > 1
             
             if isMultipleWalletsSync {
@@ -346,14 +346,14 @@ class OverviewViewController: UIViewController {
         self.syncCurrentStepTitleLabel.text = ""
         self.syncCurrentStepReportLabel.text = ""
         self.syncCurrentStepProgressLabel.text = ""
-        self.peerCountLabel.text = "\(WalletLoader.shared.multiWallet.connectedPeers())"
+        self.peerCountLabel.text = "\(multiWallet.connectedPeers())"
 
-        self.multipleWalletsPeerCountLabel.text = "\(WalletLoader.shared.multiWallet.connectedPeers())"
+        self.multipleWalletsPeerCountLabel.text = "\(multiWallet.connectedPeers())"
         MultiWalletSyncDetailsLoader.setup(for: self.multipleWalletsSyncDetailsTableView)
     }
     
     private func displayLatestBlockHeightAndAge() {
-        guard let bestBlockInfo = WalletLoader.shared.multiWallet.getBestBlock() else { return }
+        guard let bestBlockInfo = multiWallet.getBestBlock() else { return }
         
         let bestBlockHeight = bestBlockInfo.height
         let bestBlockAge = Int64(Date().timeIntervalSince1970) - bestBlockInfo.timestamp
@@ -376,7 +376,7 @@ class OverviewViewController: UIViewController {
     }
     
     private func displayConnectedPeersCount() {
-        let peerCount = WalletLoader.shared.multiWallet.connectedPeers()
+        let peerCount = multiWallet.connectedPeers()
         if peerCount == 0 {
             self.connectedPeersLabel.attributedText = NSMutableAttributedString(string: LocalizedStrings.noConnectedPeer)
             return
@@ -394,7 +394,7 @@ class OverviewViewController: UIViewController {
     }
     
     func checkWhetherToPromptForSeedBackup() {
-        let numWalletsNeedingSeedBackup = WalletLoader.shared.multiWallet.numWalletsNeedingSeedBackup()
+        let numWalletsNeedingSeedBackup = multiWallet.numWalletsNeedingSeedBackup()
         if self.hideSeedBackupPrompt || numWalletsNeedingSeedBackup == 0 {
             self.seedBackupSectionView.isHidden = true
             return
@@ -410,7 +410,7 @@ class OverviewViewController: UIViewController {
     }
     
     func checkWhetherToPromptForAccountMixing() {
-        if !WalletLoader.shared.multiWallet.readBoolConfigValue(forKey: "has_setup_privacy", defaultValue: false) && !self.hideAccountMixingPrompt {
+        if !multiWallet.readBoolConfigValue(forKey: "has_setup_privacy", defaultValue: false) && !self.hideAccountMixingPrompt {
             self.accountMixingPromptSectionView.isHidden = false
         }
     }
@@ -423,7 +423,7 @@ class OverviewViewController: UIViewController {
             if wallet.isAccountMixerActive() {
                 activeMixers += 1
                 WalletID = wallet.id_
-                 let wallet  = WalletLoader.shared.multiWallet.wallet(withID: WalletID)
+                 let wallet  = multiWallet.wallet(withID: WalletID)
                  if let unmixedAccountNumber = wallet?.readInt32ConfigValue(forKey: Dcrlibwallet.DcrlibwalletAccountMixerUnmixedAccount, defaultValue: -1) {
                      do {
                         if let balance  =  try wallet?.getAccountBalance(unmixedAccountNumber) {
@@ -462,7 +462,7 @@ class OverviewViewController: UIViewController {
     
     @IBAction func setupAccountMixingTapped(_ sender: Any) {
         if let walletsTabIndex = NavigationMenuTabBarController.tabItems.firstIndex(of: .wallets) {
-            WalletLoader.shared.multiWallet.setBoolConfigValueForKey(GlobalConstants.Strings.SHOWN_PRIVACY_TOOLTIP, value: false)
+            multiWallet.setBoolConfigValueForKey(GlobalConstants.Strings.SHOWN_PRIVACY_TOOLTIP, value: false)
             NavigationMenuTabBarController.instance?.navigateToTab(index: walletsTabIndex)
         }
     }
@@ -496,11 +496,11 @@ class OverviewViewController: UIViewController {
     @IBAction func syncConnectionButtonTap(_ sender: Any) {
         if SyncManager.shared.isRescanning {
             DispatchQueue.global(qos: .userInitiated).async {
-                WalletLoader.shared.multiWallet.cancelRescan()
+                self.multiWallet.cancelRescan()
             }
         } else if SyncManager.shared.isSynced || SyncManager.shared.isSyncing {
              DispatchQueue.global(qos: .userInitiated).async {
-                WalletLoader.shared.multiWallet.cancelSync()
+                self.multiWallet.cancelSync()
             }
         } else {
             SyncManager.shared.startSync(allowSyncOnCellular: Settings.syncOnCellular)
@@ -648,7 +648,7 @@ extension OverviewViewController: DcrlibwalletSyncProgressListenerProtocol {
     
     func onPeerConnectedOrDisconnected(_ numberOfConnectedPeers: Int32) {
         DispatchQueue.main.async {
-            if WalletLoader.shared.multiWallet.isSyncing() {
+            if self.multiWallet.isSyncing() {
                 self.peerCountLabel.text = "\(numberOfConnectedPeers)"
                 self.multipleWalletsPeerCountLabel.text = "\(numberOfConnectedPeers)"
             } else {
@@ -791,9 +791,9 @@ extension OverviewViewController: DcrlibwalletBlocksRescanProgressListenerProtoc
             self.toggleSingleWalletSyncDetailsViewHeight(isRescanning: true)
             self.multipleWalletsPeerCountLabel.superview?.isHidden = true
             
-            let nOpenedWallets = WalletLoader.shared.multiWallet.openedWalletsCount()
+            let nOpenedWallets = self.multiWallet.openedWalletsCount()
             if nOpenedWallets > 1 {
-                let wallet = WalletLoader.shared.multiWallet.wallet(withID: walletID)
+                let wallet = self.multiWallet.wallet(withID: walletID)
                 self.rescanWalletNameLabel.superview?.isHidden = false
                 self.rescanWalletNameLabel.text = wallet?.name
             } else {
@@ -810,7 +810,7 @@ extension OverviewViewController: DcrlibwalletBlocksRescanProgressListenerProtoc
             self.displayGeneralSyncProgress(report.generalSyncProgress)
             
             self.syncCurrentStepNumberLabel.text = LocalizedStrings.connectedPeersCount
-            self.syncCurrentStepSummaryLabel.text = "\(WalletLoader.shared.multiWallet.connectedPeers())"
+            self.syncCurrentStepSummaryLabel.text = "\(self.multiWallet.connectedPeers())"
             
             self.syncCurrentStepTitleLabel.text = LocalizedStrings.scannedBlocks
             self.syncCurrentStepReportLabel.text = "\(report.currentRescanHeight)"

--- a/Decred Wallet/Features/Overview/OverviewViewController.swift
+++ b/Decred Wallet/Features/Overview/OverviewViewController.swift
@@ -78,6 +78,8 @@ class OverviewViewController: UIViewController {
     @IBOutlet weak var multipleWalletsPeerCountTitleLabel: UILabel!
     @IBOutlet weak var multipleWalletsSyncDetailsTableView: UITableView!
     @IBOutlet weak var multipleWalletsSyncDetailsTableViewHeightConstraint: NSLayoutConstraint!
+    
+    private var multiWallet = WalletLoader.shared.multiWallet!
 
     var hideSeedBackupPrompt: Bool = false
     var hideAccountMixingPrompt: Bool = false
@@ -587,7 +589,7 @@ extension OverviewViewController: UITableViewDelegate, UITableViewDataSource {
         
         let cell = tableView.dequeueReusableCell(withIdentifier: TransactionTableViewCell.identifier) as! TransactionTableViewCell
         let tx = self.recentTransactions[indexPath.row]
-        cell.displayInfo(for: tx)
+        cell.displayInfo(for: tx, hideWalletLabel: multiWallet.loadedWalletsCount() == 1)
         return cell
     }
     

--- a/Decred Wallet/Features/Transactions/TransactionTableViewCell.swift
+++ b/Decred Wallet/Features/Transactions/TransactionTableViewCell.swift
@@ -18,12 +18,13 @@ class TransactionTableViewCell: UITableViewCell {
     @IBOutlet weak var txDateLabel: UILabel!
     @IBOutlet weak var daysCounterLabel: UILabel! // voted, revoked and expired tickets only
     @IBOutlet weak var txStatusIconImageView: UIImageView!
-
+    @IBOutlet weak var walletNameLabel: Label!
+    
     override class func height() -> CGFloat {
         return 56
     }
 
-    func displayInfo(for transaction: Transaction) {
+    func displayInfo(for transaction: Transaction, hideWalletLabel: Bool = true) {
         let txConfirmations = transaction.confirmations
         let isConfirmed = Settings.spendUnconfirmed || txConfirmations > 1
 
@@ -47,6 +48,13 @@ class TransactionTableViewCell: UITableViewCell {
         self.stakingTxAmountLabel.isHidden = transaction.type == DcrlibwalletTxTypeRegular
         self.daysCounterLabel.isHidden = !(transaction.type == DcrlibwalletTxTypeVote || transaction.type == DcrlibwalletTxTypeRevocation)
         self.voteRewardLabel.isHidden = !(transaction.type == DcrlibwalletTxTypeVote || transaction.type == DcrlibwalletTxTypeRevocation)
+        
+        self.walletNameLabel.isHidden = hideWalletLabel
+        
+        let wallet = WalletLoader.shared.multiWallet.wallet(withID: transaction.walletID)!
+        if !hideWalletLabel {
+            self.walletNameLabel.text = wallet.name
+        }
 
         if transaction.type == DcrlibwalletTxTypeRegular {
             self.displayRegularTxInfo(transaction)
@@ -57,7 +65,7 @@ class TransactionTableViewCell: UITableViewCell {
             self.displayRevocationTxInfo(transaction, ageInDays: transaction.daysToVoteOrRevoke)
             
         } else if transaction.type == DcrlibwalletTxTypeTicketPurchase {
-            self.displayTicketPurchaseInfo(transaction)
+            self.displayTicketPurchaseInfo(transaction, wallet: wallet)
         }
     }
     
@@ -103,7 +111,7 @@ class TransactionTableViewCell: UITableViewCell {
         self.daysCounterLabel.text = String(format: (ageInDays > 1 ? LocalizedStrings.days : LocalizedStrings.day), ageInDays)
     }
     
-    func displayTicketPurchaseInfo(_ transaction: Transaction) {
+    func displayTicketPurchaseInfo(_ transaction: Transaction, wallet: DcrlibwalletWallet) {
         self.txAmountOrTicketStatusLabel.text = "\(LocalizedStrings.ticket)"
         self.txTypeIconImageView?.image = UIImage(named: "ic_ticketImmature")
         self.stakingTxAmountLabel.attributedText = Utils.getAttributedString(str: transaction.dcrAmount.round(8).description, siz: 11.0, TexthexColor: UIColor.appColors.lightBluishGray)
@@ -115,10 +123,9 @@ class TransactionTableViewCell: UITableViewCell {
             self.txDateLabel.textColor = UIColor.appColors.lightBluishGray
             self.txDateLabel.text = LocalizedStrings.pending
         } else if txConfirmations > BuildConfig.TicketMaturity {
-           let wallet = WalletLoader.shared.multiWallet.wallet(withID: transaction.walletID)
             var errorValue: ObjCBool = false
             do {
-                try wallet?.ticketHasVotedOrRevoked(transaction.hash, ret0_: &errorValue)
+                try wallet.ticketHasVotedOrRevoked(transaction.hash, ret0_: &errorValue)
                 if errorValue.boolValue {
                     self.txAmountOrTicketStatusLabel.text = LocalizedStrings.purchased
                 } else {

--- a/Decred Wallet/Features/Transactions/TransactionTableViewCell.swift
+++ b/Decred Wallet/Features/Transactions/TransactionTableViewCell.swift
@@ -47,7 +47,6 @@ class TransactionTableViewCell: UITableViewCell {
         self.stakingTxAmountLabel.isHidden = transaction.type == DcrlibwalletTxTypeRegular
         self.daysCounterLabel.isHidden = !(transaction.type == DcrlibwalletTxTypeVote || transaction.type == DcrlibwalletTxTypeRevocation)
         self.voteRewardLabel.isHidden = !(transaction.type == DcrlibwalletTxTypeVote || transaction.type == DcrlibwalletTxTypeRevocation)
-        self.voteRewardLabelPadding.isHidden = !(transaction.type == DcrlibwalletTxTypeVote || transaction.type == DcrlibwalletTxTypeRevocation)
 
         if transaction.type == DcrlibwalletTxTypeRegular {
             self.displayRegularTxInfo(transaction)

--- a/Decred Wallet/Features/Transactions/TransactionTableViewCell.xib
+++ b/Decred Wallet/Features/Transactions/TransactionTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -80,6 +80,10 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="9cz-Uu-4tu" firstAttribute="leading" secondItem="uuE-xk-Fuj" secondAttribute="leading" id="apC-iF-A3d"/>
+                                            <constraint firstItem="LAe-dK-oRr" firstAttribute="leading" secondItem="9cz-Uu-4tu" secondAttribute="trailing" constant="8" id="eMV-Rg-wSn"/>
+                                        </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="5FY-3A-gAa">
                                         <rect key="frame" x="0.0" y="22.666666666666664" width="188.33333333333334" height="17.666666666666664"/>
@@ -93,6 +97,9 @@
                                         </subviews>
                                     </stackView>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstItem="uuE-xk-Fuj" firstAttribute="leading" secondItem="CLm-d4-NZG" secondAttribute="leading" id="8pE-vy-Hc2"/>
+                                </constraints>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Krx-yJ-hxW">
                                 <rect key="frame" x="188.33333333333334" y="0.0" width="117.66666666666666" height="40.333333333333336"/>
@@ -112,6 +119,9 @@
                                 </subviews>
                             </stackView>
                         </subviews>
+                        <constraints>
+                            <constraint firstItem="CLm-d4-NZG" firstAttribute="leading" secondItem="evP-hU-bDb" secondAttribute="leading" id="GTN-q2-gEo"/>
+                        </constraints>
                     </stackView>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_confirmed" translatesAutoresizingMaskIntoConstraints="NO" id="Lx9-wb-9kJ">
                         <rect key="frame" x="370" y="50" width="12" height="12"/>
@@ -148,6 +158,11 @@
             <point key="canvasLocation" x="-34" y="-149"/>
         </tableViewCell>
     </objects>
+    <designables>
+        <designable name="LAe-dK-oRr">
+            <size key="intrinsicContentSize" width="108.66666666666667" height="17.666666666666668"/>
+        </designable>
+    </designables>
     <resources>
         <image name="ic_confirmed" width="12" height="12"/>
         <image name="ic_ticketVoted" width="24" height="24"/>

--- a/Decred Wallet/Features/Transactions/TransactionTableViewCell.xib
+++ b/Decred Wallet/Features/Transactions/TransactionTableViewCell.xib
@@ -30,19 +30,19 @@
                         </constraints>
                     </imageView>
                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="FjC-Gz-h2A">
-                        <rect key="frame" x="284.66666666666669" y="37" width="101.33333333333331" height="38"/>
+                        <rect key="frame" x="273.33333333333331" y="38.666666666666664" width="112.66666666666669" height="34.999999999999993"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="Krx-yJ-hxW">
-                                <rect key="frame" x="0.0" y="0.0" width="81.333333333333329" height="38"/>
+                                <rect key="frame" x="0.0" y="0.0" width="92.666666666666671" height="35"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="752" text="Oct 22, 2018" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="11" translatesAutoresizingMaskIntoConstraints="NO" id="s9S-gM-kBM">
-                                        <rect key="frame" x="0.0" y="0.0" width="81.333333333333329" height="20.333333333333332"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="92.666666666666671" height="18.666666666666668"/>
                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                         <color key="textColor" red="0.34901960780000002" green="0.42745098040000001" blue="0.50588235290000005" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="142 days" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="VNM-Dh-lLd">
-                                        <rect key="frame" x="0.0" y="20.333333333333336" width="81.333333333333329" height="17.666666666666664"/>
+                                        <rect key="frame" x="0.0" y="18.666666666666671" width="92.666666666666671" height="16.333333333333329"/>
                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                         <color key="textColor" red="0.53725490200000003" green="0.59215686270000001" blue="0.64705882349999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -56,7 +56,7 @@
                                 </constraints>
                             </stackView>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" image="ic_confirmed" translatesAutoresizingMaskIntoConstraints="NO" id="Lx9-wb-9kJ">
-                                <rect key="frame" x="89.333333333333314" y="13" width="12" height="12"/>
+                                <rect key="frame" x="100.66666666666669" y="11.333333333333336" width="12" height="12"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="12" id="Ifj-Uz-Cye"/>
                                     <constraint firstAttribute="height" constant="12" id="Oed-EE-d5I"/>
@@ -70,21 +70,21 @@
                             <constraint firstAttribute="bottom" secondItem="Krx-yJ-hxW" secondAttribute="bottom" id="Z2R-Z9-JHV"/>
                         </constraints>
                     </stackView>
-                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="CLm-d4-NZG">
-                        <rect key="frame" x="55.999999999999986" y="36" width="220.66666666666663" height="40.333333333333343"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="CLm-d4-NZG">
+                        <rect key="frame" x="56.000000000000014" y="33.333333333333329" width="209.33333333333337" height="45.333333333333329"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="uuE-xk-Fuj">
-                                <rect key="frame" x="0.0" y="0.0" width="146" height="22.666666666666668"/>
+                                <rect key="frame" x="0.0" y="0.0" width="164" height="21"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="999" text="Vote" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="9cz-Uu-4tu">
-                                        <rect key="frame" x="0.0" y="0.0" width="33.333333333333336" height="22.666666666666668"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Vote" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="9cz-Uu-4tu">
+                                        <rect key="frame" x="0.0" y="0.0" width="36" height="21"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="18"/>
                                         <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="+1.04044861 DCR" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LAe-dK-oRr" customClass="Label" customModule="Decred_Wallet" customModuleProvider="target">
-                                        <rect key="frame" x="37.333333333333321" y="0.0" width="108.66666666666669" height="22.666666666666668"/>
+                                        <rect key="frame" x="40" y="0.0" width="124" height="21"/>
                                         <color key="backgroundColor" red="0.1764705882" green="0.84705882349999995" blue="0.63921568630000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -113,20 +113,55 @@
                                     <constraint firstItem="LAe-dK-oRr" firstAttribute="leading" secondItem="9cz-Uu-4tu" secondAttribute="trailing" constant="8" id="eMV-Rg-wSn"/>
                                 </constraints>
                             </stackView>
-                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="5FY-3A-gAa">
-                                <rect key="frame" x="0.0" y="22.666666666666664" width="107.66666666666667" height="17.666666666666664"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="rNW-ei-H1Q">
+                                <rect key="frame" x="0.0" y="25" width="173.33333333333334" height="20.333333333333329"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="751" verticalHuggingPriority="251" text="116.51637184 DCR" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="9zq-1l-9A2">
-                                        <rect key="frame" x="0.0" y="0.0" width="107.66666666666667" height="17.666666666666668"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Wallet" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="c8y-0R-Prg" customClass="Label" customModule="Decred_Wallet" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="0.0" width="46.333333333333336" height="20.333333333333332"/>
+                                        <color key="backgroundColor" red="0.95294117647058818" green="0.96078431372549022" blue="0.96470588235294119" alpha="1" colorSpace="calibratedRGB"/>
+                                        <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
+                                        <color key="textColor" red="0.34901960784313724" green="0.42745098039215684" blue="0.50588235294117645" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="topPadding">
+                                                <real key="value" value="2"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="bottomPadding">
+                                                <real key="value" value="2"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="leftPadding">
+                                                <real key="value" value="4"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="rightPadding">
+                                                <real key="value" value="4"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="borderRadius">
+                                                <real key="value" value="0.0"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                <real key="value" value="0.0"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="116.51637184 DCR" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="9zq-1l-9A2">
+                                        <rect key="frame" x="50.333333333333329" y="0.0" width="122.99999999999999" height="20.333333333333332"/>
                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                         <color key="textColor" red="0.53725490200000003" green="0.59215686270000001" blue="0.64705882349999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstItem="9zq-1l-9A2" firstAttribute="leading" secondItem="c8y-0R-Prg" secondAttribute="trailing" constant="4" id="H5L-Q6-sUR"/>
+                                    <constraint firstItem="c8y-0R-Prg" firstAttribute="leading" secondItem="rNW-ei-H1Q" secondAttribute="leading" id="KWv-vj-Vbr"/>
+                                </constraints>
                             </stackView>
                         </subviews>
                         <constraints>
                             <constraint firstItem="uuE-xk-Fuj" firstAttribute="leading" secondItem="CLm-d4-NZG" secondAttribute="leading" id="8pE-vy-Hc2"/>
+                            <constraint firstItem="rNW-ei-H1Q" firstAttribute="leading" secondItem="CLm-d4-NZG" secondAttribute="leading" id="Grk-re-69K"/>
+                            <constraint firstItem="uuE-xk-Fuj" firstAttribute="top" secondItem="CLm-d4-NZG" secondAttribute="top" id="b88-RQ-G7w"/>
+                            <constraint firstItem="rNW-ei-H1Q" firstAttribute="top" secondItem="uuE-xk-Fuj" secondAttribute="bottom" constant="4" id="kyD-lh-wyn"/>
+                            <constraint firstAttribute="bottom" secondItem="rNW-ei-H1Q" secondAttribute="bottom" id="sBH-yg-vzh"/>
                         </constraints>
                     </stackView>
                 </subviews>
@@ -152,13 +187,17 @@
                 <outlet property="txStatusIconImageView" destination="Lx9-wb-9kJ" id="QRb-bG-diW"/>
                 <outlet property="txTypeIconImageView" destination="bO7-8P-viz" id="tuF-0a-XUX"/>
                 <outlet property="voteRewardLabel" destination="LAe-dK-oRr" id="8kU-QU-kud"/>
+                <outlet property="walletNameLabel" destination="c8y-0R-Prg" id="aKa-dU-QTr"/>
             </connections>
             <point key="canvasLocation" x="-35.200000000000003" y="-149.26108374384236"/>
         </tableViewCell>
     </objects>
     <designables>
         <designable name="LAe-dK-oRr">
-            <size key="intrinsicContentSize" width="108.66666666666667" height="17.666666666666668"/>
+            <size key="intrinsicContentSize" width="124" height="16.333333333333332"/>
+        </designable>
+        <designable name="c8y-0R-Prg">
+            <size key="intrinsicContentSize" width="46.333333333333336" height="20.333333333333332"/>
         </designable>
     </designables>
     <resources>

--- a/Decred Wallet/Features/Transactions/TransactionTableViewCell.xib
+++ b/Decred Wallet/Features/Transactions/TransactionTableViewCell.xib
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -28,90 +29,95 @@
                             <constraint firstAttribute="height" constant="24" id="wOh-G1-gLB"/>
                         </constraints>
                     </imageView>
-                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="evP-hU-bDb">
-                        <rect key="frame" x="56" y="36" width="306" height="40.333333333333343"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="FjC-Gz-h2A">
+                        <rect key="frame" x="284.66666666666669" y="37" width="101.33333333333331" height="38"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="CLm-d4-NZG">
-                                <rect key="frame" x="0.0" y="0.0" width="188.33333333333334" height="40.333333333333336"/>
-                                <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="uuE-xk-Fuj">
-                                        <rect key="frame" x="0.0" y="0.0" width="188.33333333333334" height="22.666666666666668"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="751" verticalHuggingPriority="251" text="Vote" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="9cz-Uu-4tu">
-                                                <rect key="frame" x="0.0" y="0.0" width="33.333333333333336" height="22.666666666666668"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="20" id="U6i-Tm-Na7"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="18"/>
-                                                <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="243" text="+1.04044861 DCR" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LAe-dK-oRr" customClass="Label" customModule="Decred_Wallet" customModuleProvider="target">
-                                                <rect key="frame" x="41.333333333333321" y="2.3333333333333357" width="108.66666666666669" height="17.666666666666668"/>
-                                                <color key="backgroundColor" red="0.1764705882" green="0.84705882349999995" blue="0.63921568630000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="94" id="Oxy-Hw-a7Q"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
-                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <nil key="highlightedColor"/>
-                                                <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="number" keyPath="borderRadius">
-                                                        <real key="value" value="4"/>
-                                                    </userDefinedRuntimeAttribute>
-                                                    <userDefinedRuntimeAttribute type="number" keyPath="rightPadding">
-                                                        <real key="value" value="4"/>
-                                                    </userDefinedRuntimeAttribute>
-                                                    <userDefinedRuntimeAttribute type="number" keyPath="leftPadding">
-                                                        <real key="value" value="4"/>
-                                                    </userDefinedRuntimeAttribute>
-                                                    <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
-                                                        <real key="value" value="0.0"/>
-                                                    </userDefinedRuntimeAttribute>
-                                                    <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
-                                                        <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    </userDefinedRuntimeAttribute>
-                                                </userDefinedRuntimeAttributes>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="11" translatesAutoresizingMaskIntoConstraints="NO" id="S08-T6-OAS">
-                                                <rect key="frame" x="158" y="0.0" width="30.333333333333343" height="22.666666666666668"/>
-                                                <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="18"/>
-                                                <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <constraints>
-                                            <constraint firstItem="9cz-Uu-4tu" firstAttribute="leading" secondItem="uuE-xk-Fuj" secondAttribute="leading" id="apC-iF-A3d"/>
-                                            <constraint firstItem="LAe-dK-oRr" firstAttribute="leading" secondItem="9cz-Uu-4tu" secondAttribute="trailing" constant="8" id="eMV-Rg-wSn"/>
-                                        </constraints>
-                                    </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="5FY-3A-gAa">
-                                        <rect key="frame" x="0.0" y="22.666666666666664" width="188.33333333333334" height="17.666666666666664"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="751" verticalHuggingPriority="251" text="116.51637184 DCR" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="9zq-1l-9A2">
-                                                <rect key="frame" x="0.0" y="0.0" width="188.33333333333334" height="17.666666666666668"/>
-                                                <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
-                                                <color key="textColor" red="0.53725490200000003" green="0.59215686270000001" blue="0.64705882349999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                    </stackView>
-                                </subviews>
-                                <constraints>
-                                    <constraint firstItem="uuE-xk-Fuj" firstAttribute="leading" secondItem="CLm-d4-NZG" secondAttribute="leading" id="8pE-vy-Hc2"/>
-                                </constraints>
-                            </stackView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Krx-yJ-hxW">
-                                <rect key="frame" x="188.33333333333334" y="0.0" width="117.66666666666666" height="40.333333333333336"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="Krx-yJ-hxW">
+                                <rect key="frame" x="0.0" y="0.0" width="81.333333333333329" height="38"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="752" text="Oct 22, 2018" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="11" translatesAutoresizingMaskIntoConstraints="NO" id="s9S-gM-kBM">
-                                        <rect key="frame" x="0.0" y="0.0" width="117.66666666666667" height="22.666666666666668"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="81.333333333333329" height="20.333333333333332"/>
                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                         <color key="textColor" red="0.34901960780000002" green="0.42745098040000001" blue="0.50588235290000005" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="142 days" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="VNM-Dh-lLd">
-                                        <rect key="frame" x="0.0" y="22.666666666666664" width="117.66666666666667" height="17.666666666666664"/>
+                                        <rect key="frame" x="0.0" y="20.333333333333336" width="81.333333333333329" height="17.666666666666664"/>
+                                        <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
+                                        <color key="textColor" red="0.53725490200000003" green="0.59215686270000001" blue="0.64705882349999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="VNM-Dh-lLd" secondAttribute="trailing" id="04M-64-guV"/>
+                                    <constraint firstItem="VNM-Dh-lLd" firstAttribute="top" secondItem="s9S-gM-kBM" secondAttribute="bottom" id="eQr-Qt-94n"/>
+                                    <constraint firstItem="s9S-gM-kBM" firstAttribute="top" secondItem="Krx-yJ-hxW" secondAttribute="top" id="p6T-jQ-VWi"/>
+                                    <constraint firstAttribute="trailing" secondItem="s9S-gM-kBM" secondAttribute="trailing" id="rco-yc-Rbz"/>
+                                </constraints>
+                            </stackView>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" image="ic_confirmed" translatesAutoresizingMaskIntoConstraints="NO" id="Lx9-wb-9kJ">
+                                <rect key="frame" x="89.333333333333314" y="13" width="12" height="12"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="12" id="Ifj-Uz-Cye"/>
+                                    <constraint firstAttribute="height" constant="12" id="Oed-EE-d5I"/>
+                                </constraints>
+                            </imageView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="Lx9-wb-9kJ" firstAttribute="leading" secondItem="Krx-yJ-hxW" secondAttribute="trailing" constant="8" id="3yp-cY-nv1"/>
+                            <constraint firstItem="Krx-yJ-hxW" firstAttribute="top" secondItem="FjC-Gz-h2A" secondAttribute="top" id="73l-Rt-Vr5"/>
+                            <constraint firstItem="Krx-yJ-hxW" firstAttribute="leading" secondItem="FjC-Gz-h2A" secondAttribute="leading" id="JhV-19-W4T"/>
+                            <constraint firstAttribute="bottom" secondItem="Krx-yJ-hxW" secondAttribute="bottom" id="Z2R-Z9-JHV"/>
+                        </constraints>
+                    </stackView>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="CLm-d4-NZG">
+                        <rect key="frame" x="55.999999999999986" y="36" width="220.66666666666663" height="40.333333333333343"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="uuE-xk-Fuj">
+                                <rect key="frame" x="0.0" y="0.0" width="146" height="22.666666666666668"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="999" text="Vote" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="9cz-Uu-4tu">
+                                        <rect key="frame" x="0.0" y="0.0" width="33.333333333333336" height="22.666666666666668"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="18"/>
+                                        <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="+1.04044861 DCR" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LAe-dK-oRr" customClass="Label" customModule="Decred_Wallet" customModuleProvider="target">
+                                        <rect key="frame" x="37.333333333333321" y="0.0" width="108.66666666666669" height="22.666666666666668"/>
+                                        <color key="backgroundColor" red="0.1764705882" green="0.84705882349999995" blue="0.63921568630000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="borderRadius">
+                                                <real key="value" value="4"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="rightPadding">
+                                                <real key="value" value="4"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="leftPadding">
+                                                <real key="value" value="4"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                <real key="value" value="0.0"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </label>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="9cz-Uu-4tu" firstAttribute="leading" secondItem="uuE-xk-Fuj" secondAttribute="leading" id="apC-iF-A3d"/>
+                                    <constraint firstItem="LAe-dK-oRr" firstAttribute="leading" secondItem="9cz-Uu-4tu" secondAttribute="trailing" constant="8" id="eMV-Rg-wSn"/>
+                                </constraints>
+                            </stackView>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="5FY-3A-gAa">
+                                <rect key="frame" x="0.0" y="22.666666666666664" width="107.66666666666667" height="17.666666666666664"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="751" verticalHuggingPriority="251" text="116.51637184 DCR" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="9zq-1l-9A2">
+                                        <rect key="frame" x="0.0" y="0.0" width="107.66666666666667" height="17.666666666666668"/>
                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                         <color key="textColor" red="0.53725490200000003" green="0.59215686270000001" blue="0.64705882349999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -120,27 +126,20 @@
                             </stackView>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="CLm-d4-NZG" firstAttribute="leading" secondItem="evP-hU-bDb" secondAttribute="leading" id="GTN-q2-gEo"/>
+                            <constraint firstItem="uuE-xk-Fuj" firstAttribute="leading" secondItem="CLm-d4-NZG" secondAttribute="leading" id="8pE-vy-Hc2"/>
                         </constraints>
                     </stackView>
-                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_confirmed" translatesAutoresizingMaskIntoConstraints="NO" id="Lx9-wb-9kJ">
-                        <rect key="frame" x="370" y="50" width="12" height="12"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="12" id="Ifj-Uz-Cye"/>
-                            <constraint firstAttribute="height" constant="12" id="Oed-EE-d5I"/>
-                        </constraints>
-                    </imageView>
                 </subviews>
                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
-                    <constraint firstItem="evP-hU-bDb" firstAttribute="centerY" secondItem="Kan-gb-2RW" secondAttribute="centerY" id="JTY-hs-wwQ"/>
+                    <constraint firstAttribute="trailing" secondItem="FjC-Gz-h2A" secondAttribute="trailing" constant="12" id="1t7-3E-QvY"/>
+                    <constraint firstItem="FjC-Gz-h2A" firstAttribute="centerY" secondItem="Kan-gb-2RW" secondAttribute="centerY" id="49X-yP-u4c"/>
+                    <constraint firstItem="FjC-Gz-h2A" firstAttribute="leading" secondItem="CLm-d4-NZG" secondAttribute="trailing" constant="8" id="60v-R2-zVl"/>
+                    <constraint firstItem="CLm-d4-NZG" firstAttribute="leading" secondItem="bO7-8P-viz" secondAttribute="trailing" constant="16" id="6Y5-1y-CVW"/>
+                    <constraint firstItem="CLm-d4-NZG" firstAttribute="centerY" secondItem="Kan-gb-2RW" secondAttribute="centerY" id="GVM-cS-sEf"/>
                     <constraint firstItem="bO7-8P-viz" firstAttribute="centerY" secondItem="Kan-gb-2RW" secondAttribute="centerY" id="JwH-oA-Sg8"/>
-                    <constraint firstAttribute="trailing" secondItem="Lx9-wb-9kJ" secondAttribute="trailing" constant="16" id="LLJ-Vj-IAn"/>
-                    <constraint firstItem="Lx9-wb-9kJ" firstAttribute="centerY" secondItem="Kan-gb-2RW" secondAttribute="centerY" id="QfT-Rt-URt"/>
-                    <constraint firstItem="Lx9-wb-9kJ" firstAttribute="leading" secondItem="evP-hU-bDb" secondAttribute="trailing" constant="8" id="cod-RJ-akZ"/>
                     <constraint firstItem="bO7-8P-viz" firstAttribute="leading" secondItem="Kan-gb-2RW" secondAttribute="leading" constant="16" id="g4c-mA-rgy"/>
-                    <constraint firstItem="evP-hU-bDb" firstAttribute="leading" secondItem="bO7-8P-viz" secondAttribute="trailing" constant="16" id="nRp-cD-JJ9"/>
                 </constraints>
             </tableViewCellContentView>
             <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -153,9 +152,8 @@
                 <outlet property="txStatusIconImageView" destination="Lx9-wb-9kJ" id="QRb-bG-diW"/>
                 <outlet property="txTypeIconImageView" destination="bO7-8P-viz" id="tuF-0a-XUX"/>
                 <outlet property="voteRewardLabel" destination="LAe-dK-oRr" id="8kU-QU-kud"/>
-                <outlet property="voteRewardLabelPadding" destination="S08-T6-OAS" id="PD1-Rh-Box"/>
             </connections>
-            <point key="canvasLocation" x="-34" y="-149"/>
+            <point key="canvasLocation" x="-35.200000000000003" y="-149.26108374384236"/>
         </tableViewCell>
     </objects>
     <designables>
@@ -166,5 +164,8 @@
     <resources>
         <image name="ic_confirmed" width="12" height="12"/>
         <image name="ic_ticketVoted" width="24" height="24"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
Wallet name badger is displayed on the overview transaction row if there's more than one wallet and transaction row constraint issues are fixed.  

Closes #774 & #775

| <img src="https://user-images.githubusercontent.com/19960200/119998385-8de6a700-bfc8-11eb-84ad-99480bf0ddbe.PNG" height="500"> | <img src="https://user-images.githubusercontent.com/19960200/119998400-92ab5b00-bfc8-11eb-9d3e-1617489a02a9.PNG" height="500"> |
|-|-|   