### PR TITLE
update transactions page after creating/deleting a wallet

### DIFF
--- a/Decred Wallet/Features/Transactions/TransactionsViewController.swift
+++ b/Decred Wallet/Features/Transactions/TransactionsViewController.swift
@@ -64,14 +64,30 @@ class TransactionsViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        self.walletSelectorCollectionView.reloadData()
+        self.updateWalletSelectorTab()
         self.navigationController?.navigationBar.isHidden = true
-        self.selectWallet(selectedIndex: self.currentWalletSelectorIndex)
     }
 
     override public func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         self.updateWalletSelectorSteppingButtonsAndGradientColors()
         self.updateWalletSelectorGradientFrame()
+    }
+    
+    private func updateWalletSelectorTab() {
+        DispatchQueue.main.async {
+            self.setupWalletSelector()
+            self.updateWalletSelectorSteppingButtonsAndGradientColors()
+            if self.currentWalletSelectorIndex >= WalletLoader.shared.wallets.count {
+                self.currentWalletSelectorIndex = WalletLoader.shared.wallets.count - 1
+                // Previously selected wallet has been deleted, so select the first wallet
+                self.selectWallet(selectedIndex: 0)
+            } else {
+                // Select the previously selected wallet
+                self.selectWallet(selectedIndex: self.currentWalletSelectorIndex)
+            }
+        }
     }
 
     private func setupWalletSelector() {
@@ -87,6 +103,7 @@ class TransactionsViewController: UIViewController {
 
             self.walletSelectorPrevButton.setImage(UIImage(cgImage: UIImage(named: "ic_collapse")!.cgImage!, scale: CGFloat(1.0), orientation: .leftMirrored), for: .normal)
             self.walletSelectorNextButton.setImage(UIImage(cgImage: UIImage(named: "ic_collapse")!.cgImage!, scale: CGFloat(1.0), orientation: .rightMirrored), for: .normal)
+            self.walletSelectorContainerView.isHidden = false
         } else {
             self.walletSelectorContainerView.isHidden = true
         }


### PR DESCRIPTION
Resolves #777 

This PR solves the following issue;
- Wallet selector tab not updating properly when a wallet is created/deleted which sometimes caused the app to crash