### PR TITLE
Fix random overview transaction blinks

### DIFF
--- a/Decred Wallet/Extensions/Dcrlibwallet.swift
+++ b/Decred Wallet/Extensions/Dcrlibwallet.swift
@@ -166,7 +166,7 @@ extension DcrlibwalletWallet {
         
         if transactions != nil {
             // Check if there are new transactions since last time wallet history was displayed.
-            let lastTxHash = Settings.readStringValue(for: DcrlibwalletLastTxHashConfigKey)
+            let lastTxHash = self.readStringConfigValue(forKey: DcrlibwalletLastTxHashConfigKey, defaultValue: "")
             for i in 0..<transactions!.count {
                 if transactions![i].hash == lastTxHash {
                     // We've hit the last viewed tx. No need to animate this tx or futher txs.
@@ -176,7 +176,7 @@ extension DcrlibwalletWallet {
             }
             
             // Save hash for tx index 0 as last viewed tx hash.
-            Settings.setStringValue(transactions![0].hash, for: DcrlibwalletLastTxHashConfigKey)
+            self.setStringConfigValueForKey(DcrlibwalletLastTxHashConfigKey, value: transactions![0].hash)
         }
         
         return transactions
@@ -261,7 +261,7 @@ extension DcrlibwalletMultiWallet {
 
         if transactions != nil && transactions!.count > 0 {
             // Check if there are new transactions since last time wallet history was displayed.
-            let lastTxHash = Settings.readStringValue(for: DcrlibwalletLastTxHashConfigKey)
+            let lastTxHash = self.readStringConfigValue(forKey: DcrlibwalletLastTxHashConfigKey)
             for i in 0..<transactions!.count {
                 if transactions![i].hash == lastTxHash {
                     // We've hit the last viewed tx. No need to animate this tx or futher txs.
@@ -271,7 +271,7 @@ extension DcrlibwalletMultiWallet {
             }
             
             // Save hash for tx index 0 as last viewed tx hash.
-            Settings.setStringValue(transactions![0].hash, for: DcrlibwalletLastTxHashConfigKey)
+            self.setStringConfigValueForKey(DcrlibwalletLastTxHashConfigKey, value: transactions![0].hash)
         }
 
         return transactions

--- a/Decred Wallet/Features/Overview/OverviewViewController.swift
+++ b/Decred Wallet/Features/Overview/OverviewViewController.swift
@@ -855,6 +855,10 @@ extension OverviewViewController: DcrlibwalletTxAndBlockNotificationListenerProt
         }
         
         tx.animate = true
+        
+        multiWallet.setStringConfigValueForKey(DcrlibwalletLastTxHashConfigKey, value: tx.hash)
+        multiWallet.wallet(withID: tx.walletID)?.setStringConfigValueForKey(DcrlibwalletLastTxHashConfigKey, value: tx.hash)
+        
         self.recentTransactions.insert(tx, at: 0)
         if self.recentTransactions.count > 3 {
             _ = self.recentTransactions.popLast()

--- a/Decred Wallet/Features/Transactions/TransactionsViewController.swift
+++ b/Decred Wallet/Features/Transactions/TransactionsViewController.swift
@@ -292,8 +292,9 @@ extension TransactionsViewController: DcrlibwalletTxAndBlockNotificationListener
         self.newTxHashes.append(tx.hash)
         self.allTransactions.insert(tx, at: 0)
 
-        // Save hash for this tx as last viewed tx hash.
-        Settings.setStringValue(tx.hash, for: DcrlibwalletLastTxHashConfigKey)
+        let multiWallet = WalletLoader.shared.multiWallet!
+        multiWallet.setStringConfigValueForKey(DcrlibwalletLastTxHashConfigKey, value: tx.hash)
+        multiWallet.wallet(withID: tx.walletID)?.setStringConfigValueForKey(DcrlibwalletLastTxHashConfigKey, value: tx.hash)
 
         DispatchQueue.main.async {
             self.reloadTxsForCurrentFilter()


### PR DESCRIPTION
The bug was happening because the last tx hash setting was shared by all wallets and that means the last tx hash is being set by every wallet. The bug is fixed by saving the last tx hash in each wallet's config.

Closes #781