### PR TITLE
Keep screen awake during mixing

### DIFF
--- a/Decred Wallet/Features/Privacy/PrivacyViewController.swift
+++ b/Decred Wallet/Features/Privacy/PrivacyViewController.swift
@@ -169,6 +169,7 @@ class PrivacyViewController: UIViewController {
                 self.mixerStatusIcon.image = UIImage(named: "ic_alert")
                 self.mixerDropdownArrow.isHidden = false
                 self.mixingInfo.isHidden = false
+                UIApplication.shared.isIdleTimerDisabled = true
             }
         } else {
             let retV = UnsafeMutablePointer<ObjCBool>.allocate(capacity: 1)
@@ -226,6 +227,8 @@ extension PrivacyViewController: DcrlibwalletAccountMixerNotificationListenerPro
                 self.setMixerStatus()
                 self.mixerSwitch.isOn = false
                 Utils.showBanner(in: self.view, type: .success, text: LocalizedStrings.mixerHasStoppedRunning)
+                 UIApplication.shared.isIdleTimerDisabled = false
+                
             }
         }
     }

--- a/Decred Wallet/en.lproj/Localizable.strings
+++ b/Decred Wallet/en.lproj/Localizable.strings
@@ -584,8 +584,8 @@
 "mixerIsRuning" = "Mixer is running";
 "mixersAreRuning" = "Mixers are runing";
 "mixerHelperTitle" = "How to use the mixer?";
-"mixerHelperDsc" = "<span style=\"font-family: 'SourceSansPro-Regular'; font-size: 16px; color: #3D5873\">When you turn on the mixer, your unmixed DCRs in this wallet (unmixed balance) will be gradually mixed.<br/><br/><b><font color=\"#091440\">Important: keep this app opened while mixer is running.</font></b><br/><br/>Mixer will automatically stop when unmixed balance are fully mixed.</span>";
-"startMixerWarning" = "Your wallet will be unlocked until mixing completes.";
+"mixerHelperDsc" = "<span style=\"font-family: 'SourceSansPro-Regular'; font-size: 16px; color: #3D5873\">When you turn on the mixer, your unmixed DCRs in this wallet (unmixed balance) will be gradually mixed.<br/><br/><b><font color=\"#091440\">Important: keep this app opened while mixer is running. Your display would not timeout until the mixer completes, this may impact your battery life.</font></b><br/><br/>Mixer will automatically stop when unmixed balance are fully mixed.</span>";
+"startMixerWarning" = "Your wallet will be unlocked and your display will stay on until mixing completes.";
 "continueText" = "Continue";
 "unlockToStartMixing" = "Unlock your wallet to start mixing";
 "mixed" = "Mixed";

--- a/Decred Wallet/es.lproj/Localizable.strings
+++ b/Decred Wallet/es.lproj/Localizable.strings
@@ -584,8 +584,8 @@
 "mixerIsRuning" = "mixer is running";
 "mixersAreRuning" = "mixers are runing";
 "mixerHelperTitle" = "How to use the mixer?";
-"mixerHelperDsc" = "When you turn on the mixer, your unmixed DCRs in this wallet (unmixed balance) will be gradually mixed.<br/><br/><b><font color=\"#091440\">Important: keep this app opened while mixer is running.</font></b><br/><br/>Mixer will automatically stop when unmixed balance are fully mixed.";
-"startMixerWarning" = "Your wallet will be unlocked until mixing completes.";
+"mixerHelperDsc" = "When you turn on the mixer, your unmixed DCRs in this wallet (unmixed balance) will be gradually mixed.<br/><br/><b><font color=\"#091440\">Important: keep this app opened while mixer is running. Your display would not timeout until the mixer completes, this may impact your battery life.</font></b><br/><br/>Mixer will automatically stop when unmixed balance are fully mixed.";
+"startMixerWarning" = "Your wallet will be unlocked and your display will stay on until mixing completes.";
 "continueText" = "Continue";
 "unlockToStartMixing" = "Unlock your wallet to start mixing";
 "mixed" = "Mixed";

--- a/Decred Wallet/fr.lproj/Localizable.strings
+++ b/Decred Wallet/fr.lproj/Localizable.strings
@@ -584,8 +584,8 @@
 "mixerIsRuning" = "mixer is running";
 "mixersAreRuning" = "mixers are runing";
 "mixerHelperTitle" = "How to use the mixer?";
-"mixerHelperDsc" = "When you turn on the mixer, your unmixed DCRs in this wallet (unmixed balance) will be gradually mixed.<br/><br/><b><font color=\"#091440\">Important: keep this app opened while mixer is running.</font></b><br/><br/>Mixer will automatically stop when unmixed balance are fully mixed.";
-"startMixerWarning" = "Your wallet will be unlocked until mixing completes.";
+"mixerHelperDsc" = "When you turn on the mixer, your unmixed DCRs in this wallet (unmixed balance) will be gradually mixed.<br/><br/><b><font color=\"#091440\">Important: keep this app opened while mixer is running. Your display would not timeout until the mixer completes, this may impact your battery life.</font></b><br/><br/>Mixer will automatically stop when unmixed balance are fully mixed.";
+"startMixerWarning" = "Your wallet will be unlocked and your display will stay on until mixing completes.";
 "continueText" = "Continue";
 "unlockToStartMixing" = "Unlock your wallet to start mixing";
 "mixed" = "Mixed";

--- a/Decred Wallet/pl.lproj/Localizable.strings
+++ b/Decred Wallet/pl.lproj/Localizable.strings
@@ -584,8 +584,8 @@
 "mixerIsRuning" = "mixer is running";
 "mixersAreRuning" = "mixers are runing";
 "mixerHelperTitle" = "How to use the mixer?";
-"mixerHelperDsc" = "When you turn on the mixer, your unmixed DCRs in this wallet (unmixed balance) will be gradually mixed.<br/><br/><b><font color=\"#091440\">Important: keep this app opened while mixer is running.</font></b><br/><br/>Mixer will automatically stop when unmixed balance are fully mixed.";
-"startMixerWarning" = "Your wallet will be unlocked until mixing completes.";
+"mixerHelperDsc" = "When you turn on the mixer, your unmixed DCRs in this wallet (unmixed balance) will be gradually mixed.<br/><br/><b><font color=\"#091440\">Important: keep this app opened while mixer is running. Your display would not timeout until the mixer completes, this may impact your battery life.</font></b><br/><br/>Mixer will automatically stop when unmixed balance are fully mixed.";
+"startMixerWarning" = "Your wallet will be unlocked and your display will stay on until mixing completes.";
 "continueText" = "Continue";
 "unlockToStartMixing" = "Unlock your wallet to start mixing";
 "mixed" = "Mixed";

--- a/Decred Wallet/pt-BR.lproj/Localizable.strings
+++ b/Decred Wallet/pt-BR.lproj/Localizable.strings
@@ -584,8 +584,8 @@
 "mixerIsRuning" = "mixer is running";
 "mixersAreRuning" = "mixers are runing";
 "mixerHelperTitle" = "How to use the mixer?";
-"mixerHelperDsc" = "When you turn on the mixer, your unmixed DCRs in this wallet (unmixed balance) will be gradually mixed.<br/><br/><b><font color=\"#091440\">Important: keep this app opened while mixer is running.</font></b><br/><br/>Mixer will automatically stop when unmixed balance are fully mixed.";
-"startMixerWarning" = "Your wallet will be unlocked until mixing completes.";
+"mixerHelperDsc" = "When you turn on the mixer, your unmixed DCRs in this wallet (unmixed balance) will be gradually mixed.<br/><br/><b><font color=\"#091440\">Important: keep this app opened while mixer is running. Your display would not timeout until the mixer completes, this may impact your battery life.</font></b><br/><br/>Mixer will automatically stop when unmixed balance are fully mixed.";
+"startMixerWarning" = "Your wallet will be unlocked and your display will stay on until mixing completes.";
 "continueText" = "Continue";
 "unlockToStartMixing" = "Unlock your wallet to start mixing";
 "mixed" = "Mixed";

--- a/Decred Wallet/ru-RU.lproj/Localizable.strings
+++ b/Decred Wallet/ru-RU.lproj/Localizable.strings
@@ -584,8 +584,8 @@
 "mixerIsRuning" = "mixer is running";
 "mixersAreRuning" = "mixers are runing";
 "mixerHelperTitle" = "How to use the mixer?";
-"mixerHelperDsc" = "When you turn on the mixer, your unmixed DCRs in this wallet (unmixed balance) will be gradually mixed.<br/><br/><b><font color=\"#091440\">Important: keep this app opened while mixer is running.</font></b><br/><br/>Mixer will automatically stop when unmixed balance are fully mixed.";
-"startMixerWarning" = "Your wallet will be unlocked until mixing completes.";
+"mixerHelperDsc" = "When you turn on the mixer, your unmixed DCRs in this wallet (unmixed balance) will be gradually mixed.<br/><br/><b><font color=\"#091440\">Important: keep this app opened while mixer is running. Your display would not timeout until the mixer completes, this may impact your battery life.</font></b><br/><br/>Mixer will automatically stop when unmixed balance are fully mixed.";
+"startMixerWarning" = "Your wallet will be unlocked and your display will stay on until mixing completes.";
 "continueText" = "Continue";
 "unlockToStartMixing" = "Unlock your wallet to start mixing";
 "mixed" = "Mixed";

--- a/Decred Wallet/vi.lproj/Localizable.strings
+++ b/Decred Wallet/vi.lproj/Localizable.strings
@@ -584,8 +584,8 @@
 "mixerIsRuning" = "mixer is running";
 "mixersAreRuning" = "mixers are runing";
 "mixerHelperTitle" = "How to use the mixer?";
-"mixerHelperDsc" = "When you turn on the mixer, your unmixed DCRs in this wallet (unmixed balance) will be gradually mixed.<br/><br/><b><font color=\"#091440\">Important: keep this app opened while mixer is running.</font></b><br/><br/>Mixer will automatically stop when unmixed balance are fully mixed.";
-"startMixerWarning" = "Your wallet will be unlocked until mixing completes.";
+"mixerHelperDsc" = "When you turn on the mixer, your unmixed DCRs in this wallet (unmixed balance) will be gradually mixed.<br/><br/><b><font color=\"#091440\">Important: keep this app opened while mixer is running. Your display would not timeout until the mixer completes, this may impact your battery life.</font></b><br/><br/>Mixer will automatically stop when unmixed balance are fully mixed.";
+"startMixerWarning" = "Your wallet will be unlocked and your display will stay on until mixing completes.";
 "continueText" = "Continue";
 "unlockToStartMixing" = "Unlock your wallet to start mixing";
 "mixed" = "Mixed";

--- a/Decred Wallet/zh-Hans.lproj/Localizable.strings
+++ b/Decred Wallet/zh-Hans.lproj/Localizable.strings
@@ -584,8 +584,8 @@
 "mixerIsRuning" = "mixer is running";
 "mixersAreRuning" = "mixers are runing";
 "mixerHelperTitle" = "How to use the mixer?";
-"mixerHelperDsc" = "When you turn on the mixer, your unmixed DCRs in this wallet (unmixed balance) will be gradually mixed.<br/><br/><b><font color=\"#091440\">Important: keep this app opened while mixer is running.</font></b><br/><br/>Mixer will automatically stop when unmixed balance are fully mixed.";
-"startMixerWarning" = "Your wallet will be unlocked until mixing completes.";
+"mixerHelperDsc" = "When you turn on the mixer, your unmixed DCRs in this wallet (unmixed balance) will be gradually mixed.<br/><br/><b><font color=\"#091440\">Important: keep this app opened while mixer is running. Your display would not timeout until the mixer completes, this may impact your battery life.</font></b><br/><br/>Mixer will automatically stop when unmixed balance are fully mixed.";
+"startMixerWarning" = "Your wallet will be unlocked and your display will stay on until mixing completes.";
 "continueText" = "Continue";
 "unlockToStartMixing" = "Unlock your wallet to start mixing";
 "mixed" = "Mixed";


### PR DESCRIPTION
Resolves #769 

Resolves issue of screen sleeping while mixing and adds relevant messages. Display continues normal function after mixing is complete or stopped.

screenshots
![WhatsApp Image 2021-06-01 at 10 51 19 AM-2](https://user-images.githubusercontent.com/54014025/120369925-d2c05580-c2c8-11eb-97bf-bea77c0e2a25.jpeg)

![WhatsApp Image 2021-06-01 at 10 51 19 AM](https://user-images.githubusercontent.com/54014025/120370114-056a4e00-c2c9-11eb-90e1-21ee3b5241c2.jpeg)

