### PR TITLE
send page: indicate mixed transaction change destination account

### DIFF
--- a/Decred Wallet/Features/Overview/OverviewViewController.swift
+++ b/Decred Wallet/Features/Overview/OverviewViewController.swift
@@ -117,7 +117,8 @@ class OverviewViewController: UIViewController {
         
         multiWallet.setBlocksRescanProgressListener(self)
         
-        multiWallet.setAccountMixerNotification(self)
+        let accountMixerNotification = self as DcrlibwalletAccountMixerNotificationListenerProtocol
+        try? WalletLoader.shared.multiWallet.add(accountMixerNotification, uniqueIdentifier: "\(self)")
 
         // Display latest block and connected peer count if there's no ongoing sync.
         if !SyncManager.shared.isSyncing {

--- a/Decred Wallet/Features/Overview/OverviewViewController.swift
+++ b/Decred Wallet/Features/Overview/OverviewViewController.swift
@@ -118,7 +118,7 @@ class OverviewViewController: UIViewController {
         multiWallet.setBlocksRescanProgressListener(self)
         
         let accountMixerNotification = self as DcrlibwalletAccountMixerNotificationListenerProtocol
-        try? WalletLoader.shared.multiWallet.add(accountMixerNotification, uniqueIdentifier: "\(self)")
+        try? multiWallet.add(accountMixerNotification, uniqueIdentifier: "\(self)")
 
         // Display latest block and connected peer count if there's no ongoing sync.
         if !SyncManager.shared.isSyncing {

--- a/Decred Wallet/Features/Privacy/Privacy.storyboard
+++ b/Decred Wallet/Features/Privacy/Privacy.storyboard
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -17,27 +19,27 @@
             <objects>
                 <viewController storyboardIdentifier="PrivacySetupViewController" automaticallyAdjustsScrollViewInsets="NO" id="wgY-rn-Il0" customClass="PrivacySetupViewController" customModule="Decred_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="gG9-rO-dLJ">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="juu-1Y-VBr">
-                                <rect key="frame" x="16" y="27" width="17" height="22"/>
+                                <rect key="frame" x="16" y="73" width="17" height="22"/>
                                 <state key="normal" image="left-arrow"/>
                                 <connections>
                                     <action selector="dismissView:" destination="wgY-rn-Il0" eventType="touchUpInside" id="60h-Wq-yoe"/>
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hR2-rF-Y9z">
-                                <rect key="frame" x="53" y="16" width="531" height="44"/>
+                                <rect key="frame" x="53" y="60" width="345" height="47.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Privacy" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X3w-9x-ZBp">
-                                        <rect key="frame" x="0.0" y="0.0" width="531" height="23.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="345" height="25.5"/>
                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="20"/>
                                         <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="mywallet" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WsD-vo-weA">
-                                        <rect key="frame" x="0.0" y="27.5" width="531" height="16.5"/>
+                                        <rect key="frame" x="0.0" y="29.5" width="345" height="18"/>
                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                         <color key="textColor" red="0.34901960780000002" green="0.42745098040000001" blue="0.50588235290000005" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
@@ -55,10 +57,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tJ9-IZ-mUK">
-                                <rect key="frame" x="0.0" y="485" width="600" height="115"/>
+                                <rect key="frame" x="0.0" y="781" width="414" height="115"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ayu-ew-FJN" customClass="Button" customModule="Decred_Wallet" customModuleProvider="target">
-                                        <rect key="frame" x="24" y="16" width="552" height="48"/>
+                                        <rect key="frame" x="24" y="16" width="366" height="48"/>
                                         <color key="backgroundColor" red="0.16078431369999999" green="0.43921568630000002" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="48" id="hRp-eG-NH3"/>
@@ -93,7 +95,7 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Using mixed DCRs protects you from exposing your financial activities to the public (e.g. how much you own, who pays you)." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r99-Th-V8r">
-                                <rect key="frame" x="24" y="310.5" width="552" height="37.5"/>
+                                <rect key="frame" x="24" y="406.5" width="366" height="60.5"/>
                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                 <color key="textColor" red="0.23921568630000001" green="0.34509803919999998" blue="0.45098039220000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -102,7 +104,7 @@
                                 </userDefinedRuntimeAttributes>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CoinShuffle++ mixer can mix your DCRs through CoinJoin transactions." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VKM-Zr-NfH">
-                                <rect key="frame" x="24" y="275.5" width="552" height="19"/>
+                                <rect key="frame" x="24" y="350" width="366" height="40.5"/>
                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                 <color key="textColor" red="0.23921568630000001" green="0.34509803919999998" blue="0.45098039220000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -111,7 +113,7 @@
                                 </userDefinedRuntimeAttributes>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="How does CoinShuffle++ mixer enhance your privacy?" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GdO-Vh-lbu">
-                                <rect key="frame" x="24" y="236" width="552" height="23.5"/>
+                                <rect key="frame" x="24" y="283.5" width="366" height="50.5"/>
                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="20"/>
                                 <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -120,7 +122,7 @@
                                 </userDefinedRuntimeAttributes>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_mixer_setup" translatesAutoresizingMaskIntoConstraints="NO" id="9CY-qv-AB2">
-                                <rect key="frame" x="40" y="84" width="520" height="128"/>
+                                <rect key="frame" x="40" y="131.5" width="334" height="128"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="128" id="beD-Pd-bZq"/>
                                 </constraints>
@@ -166,14 +168,14 @@
             <objects>
                 <viewController storyboardIdentifier="PrivacyViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="y16-2g-f1O" customClass="PrivacyViewController" customModule="Decred_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="iEF-jc-dcn">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="IKe-Ji-zhC">
-                                <rect key="frame" x="24" y="16" width="552" height="40"/>
+                                <rect key="frame" x="24" y="60" width="366" height="43.5"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zh9-Ye-9ub">
-                                        <rect key="frame" x="0.0" y="9" width="16.5" height="22"/>
+                                        <rect key="frame" x="0.0" y="11" width="16.5" height="22"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="16.5" id="Jdm-qj-aZY"/>
                                         </constraints>
@@ -184,16 +186,16 @@
                                         </connections>
                                     </button>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="C3h-pB-sWg">
-                                        <rect key="frame" x="32.5" y="0.0" width="473.5" height="40"/>
+                                        <rect key="frame" x="32.5" y="0.0" width="287.5" height="43.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Privacy" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZgL-Gd-zyW">
-                                                <rect key="frame" x="0.0" y="0.0" width="473.5" height="23.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="287.5" height="25.5"/>
                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="20"/>
                                                 <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="mywallet" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HEi-mE-cds">
-                                                <rect key="frame" x="0.0" y="23.5" width="473.5" height="16.5"/>
+                                                <rect key="frame" x="0.0" y="25.5" width="287.5" height="18"/>
                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                 <color key="textColor" red="0.34901960784313724" green="0.42745098039215684" blue="0.50588235294117645" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -201,7 +203,7 @@
                                         </subviews>
                                     </stackView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vl1-xB-GUb">
-                                        <rect key="frame" x="522" y="5" width="30" height="30"/>
+                                        <rect key="frame" x="336" y="7" width="30" height="30"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="30" id="aSG-q6-0Lw"/>
                                             <constraint firstAttribute="height" constant="30" id="tv2-d6-pt5"/>
@@ -214,22 +216,22 @@
                                 </subviews>
                             </stackView>
                             <scrollView clipsSubviews="YES" contentMode="scaleToFill" directionalLockEnabled="YES" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" contentInsetAdjustmentBehavior="always" keyboardDismissMode="interactive" translatesAutoresizingMaskIntoConstraints="NO" id="cps-S7-OnL">
-                                <rect key="frame" x="0.0" y="72" width="600" height="528"/>
+                                <rect key="frame" x="0.0" y="119.5" width="414" height="776.5"/>
                                 <subviews>
                                     <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="byB-XZ-r7u">
-                                        <rect key="frame" x="0.0" y="0.0" width="600" height="651"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="651"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Idp-TG-tQE">
-                                                <rect key="frame" x="8" y="8" width="584" height="147"/>
+                                                <rect key="frame" x="8" y="8" width="398" height="147"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xsQ-Gg-deo" customClass="RoundedView" customModule="Decred_Wallet" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="0.0" width="584" height="147"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="398" height="147"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="s8T-d8-0GV">
-                                                                <rect key="frame" x="0.0" y="0.0" width="584" height="147"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="398" height="147"/>
                                                                 <subviews>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qWu-tc-hle">
-                                                                        <rect key="frame" x="0.0" y="8" width="584" height="43"/>
+                                                                        <rect key="frame" x="0.0" y="8" width="398" height="43"/>
                                                                         <subviews>
                                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="300" verticalHuggingPriority="300" image="ic_mixer" translatesAutoresizingMaskIntoConstraints="NO" id="0Ka-JI-Yt4">
                                                                                 <rect key="frame" x="16" y="9.5" width="24" height="24"/>
@@ -239,16 +241,16 @@
                                                                                 </constraints>
                                                                             </imageView>
                                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="TWX-kd-Q96">
-                                                                                <rect key="frame" x="56" y="0.5" width="455" height="42"/>
+                                                                                <rect key="frame" x="56" y="0.5" width="269" height="42"/>
                                                                                 <subviews>
                                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Mixer" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8dv-TH-uiv">
-                                                                                        <rect key="frame" x="0.0" y="0.0" width="455" height="21"/>
+                                                                                        <rect key="frame" x="0.0" y="0.0" width="269" height="21"/>
                                                                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="18"/>
                                                                                         <color key="textColor" red="0.035294117647058823" green="0.078431372549019607" blue="0.25098039215686274" alpha="1" colorSpace="calibratedRGB"/>
                                                                                         <nil key="highlightedColor"/>
                                                                                     </label>
                                                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="aSn-zl-5vC">
-                                                                                        <rect key="frame" x="0.0" y="21" width="455" height="21"/>
+                                                                                        <rect key="frame" x="0.0" y="21" width="269" height="21"/>
                                                                                         <subviews>
                                                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_alert" translatesAutoresizingMaskIntoConstraints="NO" id="7nI-di-gG5">
                                                                                                 <rect key="frame" x="0.0" y="2.5" width="16" height="16"/>
@@ -258,7 +260,7 @@
                                                                                                 </constraints>
                                                                                             </imageView>
                                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Ready to mix" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="11" translatesAutoresizingMaskIntoConstraints="NO" id="Jqn-P3-Y9X">
-                                                                                                <rect key="frame" x="20" y="2.5" width="435" height="16.5"/>
+                                                                                                <rect key="frame" x="20" y="1.5" width="249" height="18"/>
                                                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                                                                 <color key="textColor" red="0.34901960784313724" green="0.42745098039215684" blue="0.50588235294117645" alpha="1" colorSpace="calibratedRGB"/>
                                                                                                 <nil key="highlightedColor"/>
@@ -274,7 +276,7 @@
                                                                                 </constraints>
                                                                             </stackView>
                                                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="5ap-ty-ttF">
-                                                                                <rect key="frame" x="519" y="6" width="51" height="31"/>
+                                                                                <rect key="frame" x="333" y="6" width="51" height="31"/>
                                                                                 <color key="onTintColor" red="0.16078431372549018" green="0.4392156862745098" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <connections>
                                                                                     <action selector="mixAccount:" destination="y16-2g-f1O" eventType="valueChanged" id="MoB-dv-F7x"/>
@@ -294,10 +296,10 @@
                                                                         </constraints>
                                                                     </view>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nw7-9G-ofI" customClass="RoundedView" customModule="Decred_Wallet" customModuleProvider="target">
-                                                                        <rect key="frame" x="16" y="67" width="552" height="72"/>
+                                                                        <rect key="frame" x="16" y="67" width="366" height="72"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unmixed balance" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2X5-xl-U8x">
-                                                                                <rect key="frame" x="16" y="17.5" width="298" height="16.5"/>
+                                                                                <rect key="frame" x="16" y="17.5" width="197.5" height="18"/>
                                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                                                 <color key="textColor" red="0.34901960780000002" green="0.42745098040000001" blue="0.50588235290000005" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <nil key="highlightedColor"/>
@@ -306,20 +308,20 @@
                                                                                 </userDefinedRuntimeAttributes>
                                                                             </label>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0.74431858 DCR" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="11" translatesAutoresizingMaskIntoConstraints="NO" id="AXV-IJ-5qC">
-                                                                                <rect key="frame" x="334" y="16" width="202" height="19"/>
+                                                                                <rect key="frame" x="216" y="16" width="134" height="20.5"/>
                                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                                                                 <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <imageView hidden="YES" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_downArrow" translatesAutoresizingMaskIntoConstraints="NO" id="qDX-Ib-0qo">
-                                                                                <rect key="frame" x="264" y="24" width="24" height="24"/>
+                                                                                <rect key="frame" x="171" y="24" width="24" height="24"/>
                                                                                 <constraints>
                                                                                     <constraint firstAttribute="height" constant="24" id="PF1-yd-P3I"/>
                                                                                     <constraint firstAttribute="width" constant="24" id="o7o-LF-lt9"/>
                                                                                 </constraints>
                                                                             </imageView>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Mixed balance" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8e0-09-jpF">
-                                                                                <rect key="frame" x="16" y="46.5" width="92" height="16.5"/>
+                                                                                <rect key="frame" x="16" y="45" width="83.5" height="18"/>
                                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                                                 <color key="textColor" red="0.34901960780000002" green="0.42745098040000001" blue="0.50588235290000005" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <nil key="highlightedColor"/>
@@ -328,7 +330,7 @@
                                                                                 </userDefinedRuntimeAttributes>
                                                                             </label>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0 DCR" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="11" translatesAutoresizingMaskIntoConstraints="NO" id="qNx-so-qhl">
-                                                                                <rect key="frame" x="315" y="45" width="221" height="19"/>
+                                                                                <rect key="frame" x="203.5" y="43.5" width="146.5" height="20.5"/>
                                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                                                                 <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <nil key="highlightedColor"/>
@@ -359,7 +361,7 @@
                                                                         </userDefinedRuntimeAttributes>
                                                                     </view>
                                                                     <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Mixer will automatically stop when unmixed balance are fully mixed." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vBM-NH-GCu">
-                                                                        <rect key="frame" x="16" y="139" width="552" height="0.0"/>
+                                                                        <rect key="frame" x="16" y="139" width="366" height="0.0"/>
                                                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                                         <color key="textColor" red="0.34901960784313724" green="0.42745098039215684" blue="0.50588235294117645" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
@@ -407,22 +409,22 @@
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ePs-DK-No0">
-                                                <rect key="frame" x="8" y="163" width="584" height="366"/>
+                                                <rect key="frame" x="8" y="163" width="398" height="441"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E9o-5T-moY" customClass="RoundedView" customModule="Decred_Wallet" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="0.0" width="584" height="366"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="398" height="441"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="INe-A6-aE8">
-                                                                <rect key="frame" x="0.0" y="0.0" width="584" height="366"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="398" height="441"/>
                                                                 <subviews>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rrZ-eW-qVi">
-                                                                        <rect key="frame" x="0.0" y="8" width="584" height="30"/>
+                                                                        <rect key="frame" x="0.0" y="8" width="398" height="30"/>
                                                                         <subviews>
                                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="q7A-X5-BXP">
-                                                                                <rect key="frame" x="16" y="-6" width="90" height="42"/>
+                                                                                <rect key="frame" x="16" y="-6" width="82" height="42"/>
                                                                                 <subviews>
                                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Mixer Settings" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2kw-V3-N78">
-                                                                                        <rect key="frame" x="0.0" y="0.0" width="90" height="42"/>
+                                                                                        <rect key="frame" x="0.0" y="0.0" width="82" height="42"/>
                                                                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                                                         <color key="textColor" red="0.23921568630000001" green="0.34509803919999998" blue="0.45098039220000002" alpha="1" colorSpace="calibratedRGB"/>
                                                                                         <nil key="highlightedColor"/>
@@ -444,13 +446,13 @@
                                                                         </constraints>
                                                                     </view>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HkK-PN-lqS">
-                                                                        <rect key="frame" x="0.0" y="38" width="584" height="64"/>
+                                                                        <rect key="frame" x="0.0" y="38" width="398" height="64"/>
                                                                         <subviews>
                                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="SxH-4F-hqF">
-                                                                                <rect key="frame" x="16" y="11" width="106.5" height="42"/>
+                                                                                <rect key="frame" x="16" y="11" width="96" height="42"/>
                                                                                 <subviews>
                                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Mixed account" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oNU-9W-nyv">
-                                                                                        <rect key="frame" x="0.0" y="0.0" width="106.5" height="21"/>
+                                                                                        <rect key="frame" x="0.0" y="0.0" width="96" height="21"/>
                                                                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                                                                         <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
                                                                                         <nil key="highlightedColor"/>
@@ -459,7 +461,7 @@
                                                                                         </userDefinedRuntimeAttributes>
                                                                                     </label>
                                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="mixed" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YPA-lh-ntY">
-                                                                                        <rect key="frame" x="0.0" y="21" width="106.5" height="21"/>
+                                                                                        <rect key="frame" x="0.0" y="21" width="96" height="21"/>
                                                                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                                                         <color key="textColor" red="0.34901960780000002" green="0.42745098040000001" blue="0.50588235290000005" alpha="1" colorSpace="calibratedRGB"/>
                                                                                         <nil key="highlightedColor"/>
@@ -478,20 +480,20 @@
                                                                         </constraints>
                                                                     </view>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2Qr-vR-7XY">
-                                                                        <rect key="frame" x="0.0" y="102" width="584" height="64"/>
+                                                                        <rect key="frame" x="0.0" y="102" width="398" height="64"/>
                                                                         <subviews>
                                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oA5-kW-eQT">
-                                                                                <rect key="frame" x="16" y="0.0" width="568" height="0.5"/>
+                                                                                <rect key="frame" x="16" y="0.0" width="382" height="0.5"/>
                                                                                 <color key="backgroundColor" red="0.90196078430000004" green="0.91764705879999997" blue="0.92941176469999998" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <constraints>
                                                                                     <constraint firstAttribute="height" constant="0.5" id="9su-ml-Zmm"/>
                                                                                 </constraints>
                                                                             </view>
                                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="XQi-Mo-Ugm">
-                                                                                <rect key="frame" x="16" y="11" width="126.5" height="42"/>
+                                                                                <rect key="frame" x="16" y="11" width="117" height="42"/>
                                                                                 <subviews>
                                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unmixed account" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j6e-MG-3cz">
-                                                                                        <rect key="frame" x="0.0" y="0.0" width="126.5" height="21"/>
+                                                                                        <rect key="frame" x="0.0" y="0.0" width="117" height="21"/>
                                                                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                                                                         <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
                                                                                         <nil key="highlightedColor"/>
@@ -500,7 +502,7 @@
                                                                                         </userDefinedRuntimeAttributes>
                                                                                     </label>
                                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="unmixed" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dzW-0z-f9y">
-                                                                                        <rect key="frame" x="0.0" y="21" width="126.5" height="21"/>
+                                                                                        <rect key="frame" x="0.0" y="21" width="117" height="21"/>
                                                                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                                                         <color key="textColor" red="0.34901960780000002" green="0.42745098040000001" blue="0.50588235290000005" alpha="1" colorSpace="calibratedRGB"/>
                                                                                         <nil key="highlightedColor"/>
@@ -522,20 +524,20 @@
                                                                         </constraints>
                                                                     </view>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TKq-5f-vww">
-                                                                        <rect key="frame" x="0.0" y="166" width="584" height="64"/>
+                                                                        <rect key="frame" x="0.0" y="166" width="398" height="64"/>
                                                                         <subviews>
                                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hL4-Cf-yO3">
-                                                                                <rect key="frame" x="16" y="0.0" width="568" height="0.5"/>
+                                                                                <rect key="frame" x="16" y="0.0" width="382" height="0.5"/>
                                                                                 <color key="backgroundColor" red="0.90196078430000004" green="0.91764705879999997" blue="0.92941176469999998" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <constraints>
                                                                                     <constraint firstAttribute="height" constant="0.5" id="1er-oE-kVQ"/>
                                                                                 </constraints>
                                                                             </view>
                                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="GUD-gu-K3B">
-                                                                                <rect key="frame" x="16" y="11" width="160.5" height="42"/>
+                                                                                <rect key="frame" x="16" y="11" width="146" height="42"/>
                                                                                 <subviews>
                                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Mixed account branch" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aJQ-AV-rgX">
-                                                                                        <rect key="frame" x="0.0" y="0.0" width="160.5" height="21"/>
+                                                                                        <rect key="frame" x="0.0" y="0.0" width="146" height="21"/>
                                                                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                                                                         <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
                                                                                         <nil key="highlightedColor"/>
@@ -544,7 +546,7 @@
                                                                                         </userDefinedRuntimeAttributes>
                                                                                     </label>
                                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4UL-Ur-qDb">
-                                                                                        <rect key="frame" x="0.0" y="21" width="160.5" height="21"/>
+                                                                                        <rect key="frame" x="0.0" y="21" width="146" height="21"/>
                                                                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                                                         <color key="textColor" red="0.34901960780000002" green="0.42745098040000001" blue="0.50588235290000005" alpha="1" colorSpace="calibratedRGB"/>
                                                                                         <nil key="highlightedColor"/>
@@ -566,20 +568,20 @@
                                                                         </constraints>
                                                                     </view>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3Ap-lI-T3q">
-                                                                        <rect key="frame" x="0.0" y="230" width="584" height="64"/>
+                                                                        <rect key="frame" x="0.0" y="230" width="398" height="64"/>
                                                                         <subviews>
                                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jKa-Yu-y8z">
-                                                                                <rect key="frame" x="16" y="0.0" width="568" height="0.5"/>
+                                                                                <rect key="frame" x="16" y="0.0" width="382" height="0.5"/>
                                                                                 <color key="backgroundColor" red="0.90196078430000004" green="0.91764705879999997" blue="0.92941176469999998" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <constraints>
                                                                                     <constraint firstAttribute="height" constant="0.5" id="l76-K7-HLS"/>
                                                                                 </constraints>
                                                                             </view>
                                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Q9M-7y-zdk">
-                                                                                <rect key="frame" x="16" y="11" width="103" height="42"/>
+                                                                                <rect key="frame" x="16" y="11" width="94.5" height="42"/>
                                                                                 <subviews>
                                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Mix server" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lvo-3Y-h5P">
-                                                                                        <rect key="frame" x="0.0" y="0.0" width="103" height="21"/>
+                                                                                        <rect key="frame" x="0.0" y="0.0" width="94.5" height="21"/>
                                                                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                                                                         <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
                                                                                         <nil key="highlightedColor"/>
@@ -588,7 +590,7 @@
                                                                                         </userDefinedRuntimeAttributes>
                                                                                     </label>
                                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="cspp.decred.org" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iO4-dT-fWB">
-                                                                                        <rect key="frame" x="0.0" y="21" width="103" height="21"/>
+                                                                                        <rect key="frame" x="0.0" y="21" width="94.5" height="21"/>
                                                                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                                                         <color key="textColor" red="0.34901960780000002" green="0.42745098040000001" blue="0.50588235290000005" alpha="1" colorSpace="calibratedRGB"/>
                                                                                         <nil key="highlightedColor"/>
@@ -610,20 +612,20 @@
                                                                         </constraints>
                                                                     </view>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DRO-9H-eDq">
-                                                                        <rect key="frame" x="0.0" y="294" width="584" height="64"/>
+                                                                        <rect key="frame" x="0.0" y="294" width="398" height="64"/>
                                                                         <subviews>
                                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nfn-xX-pff">
-                                                                                <rect key="frame" x="16" y="0.0" width="568" height="0.5"/>
+                                                                                <rect key="frame" x="16" y="0.0" width="382" height="0.5"/>
                                                                                 <color key="backgroundColor" red="0.90196078430000004" green="0.91764705879999997" blue="0.92941176469999998" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <constraints>
                                                                                     <constraint firstAttribute="height" constant="0.5" id="riV-6k-qff"/>
                                                                                 </constraints>
                                                                             </view>
                                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="zNa-L0-D0P">
-                                                                                <rect key="frame" x="16" y="11" width="80" height="42"/>
+                                                                                <rect key="frame" x="16" y="11" width="75.5" height="42"/>
                                                                                 <subviews>
                                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Server port" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mNa-8S-H8L">
-                                                                                        <rect key="frame" x="0.0" y="0.0" width="80" height="21"/>
+                                                                                        <rect key="frame" x="0.0" y="0.0" width="75.5" height="21"/>
                                                                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                                                                         <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
                                                                                         <nil key="highlightedColor"/>
@@ -632,7 +634,7 @@
                                                                                         </userDefinedRuntimeAttributes>
                                                                                     </label>
                                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="15760" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HYB-Jv-1h0">
-                                                                                        <rect key="frame" x="0.0" y="21" width="80" height="21"/>
+                                                                                        <rect key="frame" x="0.0" y="21" width="75.5" height="21"/>
                                                                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                                                         <color key="textColor" red="0.34901960780000002" green="0.42745098040000001" blue="0.50588235290000005" alpha="1" colorSpace="calibratedRGB"/>
                                                                                         <nil key="highlightedColor"/>
@@ -653,11 +655,65 @@
                                                                             <constraint firstItem="nfn-xX-pff" firstAttribute="top" secondItem="DRO-9H-eDq" secondAttribute="top" id="gpx-Ct-EVB"/>
                                                                         </constraints>
                                                                     </view>
+                                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LYZ-47-tMs">
+                                                                        <rect key="frame" x="0.0" y="358" width="398" height="75"/>
+                                                                        <subviews>
+                                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ipj-Qb-dFT">
+                                                                                <rect key="frame" x="16" y="0.0" width="382" height="0.5"/>
+                                                                                <color key="backgroundColor" red="0.90196078430000004" green="0.91764705879999997" blue="0.92941176469999998" alpha="1" colorSpace="calibratedRGB"/>
+                                                                                <constraints>
+                                                                                    <constraint firstAttribute="height" constant="0.5" id="mC5-gf-1IT"/>
+                                                                                </constraints>
+                                                                            </view>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Mix change" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UX8-iM-mvM">
+                                                                                <rect key="frame" x="16" y="11" width="74.5" height="20.5"/>
+                                                                                <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
+                                                                                <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
+                                                                                <nil key="highlightedColor"/>
+                                                                                <userDefinedRuntimeAttributes>
+                                                                                    <userDefinedRuntimeAttribute type="string" keyPath="xibLocalizedStringKey" value="mixTxChange"/>
+                                                                                </userDefinedRuntimeAttributes>
+                                                                            </label>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Change on transactions from all accounts will go to unmixed" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cd0-w2-gb2">
+                                                                                <rect key="frame" x="16" y="33.5" width="309" height="35.5"/>
+                                                                                <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
+                                                                                <color key="textColor" red="0.34901960780000002" green="0.42745098040000001" blue="0.50588235290000005" alpha="1" colorSpace="calibratedRGB"/>
+                                                                                <nil key="highlightedColor"/>
+                                                                            </label>
+                                                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="BCh-oh-AhT">
+                                                                                <rect key="frame" x="333" y="22" width="51" height="31"/>
+                                                                                <constraints>
+                                                                                    <constraint firstAttribute="width" constant="49" id="aF3-FK-U3l"/>
+                                                                                    <constraint firstAttribute="height" constant="31" id="agd-7o-QDR"/>
+                                                                                </constraints>
+                                                                                <color key="onTintColor" red="0.16078431369999999" green="0.43921568630000002" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                                                <connections>
+                                                                                    <action selector="mixChangeSwitch:" destination="y16-2g-f1O" eventType="valueChanged" id="yVc-r4-m2Z"/>
+                                                                                </connections>
+                                                                            </switch>
+                                                                        </subviews>
+                                                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                        <constraints>
+                                                                            <constraint firstItem="cd0-w2-gb2" firstAttribute="leading" secondItem="LYZ-47-tMs" secondAttribute="leading" constant="16" id="6Xc-BY-AOc"/>
+                                                                            <constraint firstItem="Ipj-Qb-dFT" firstAttribute="top" secondItem="LYZ-47-tMs" secondAttribute="top" id="74o-yP-uFd"/>
+                                                                            <constraint firstItem="cd0-w2-gb2" firstAttribute="top" secondItem="UX8-iM-mvM" secondAttribute="bottom" constant="2" id="BPn-lE-cgG"/>
+                                                                            <constraint firstItem="BCh-oh-AhT" firstAttribute="centerY" secondItem="LYZ-47-tMs" secondAttribute="centerY" id="Gb4-Ad-fdc"/>
+                                                                            <constraint firstItem="BCh-oh-AhT" firstAttribute="leading" secondItem="cd0-w2-gb2" secondAttribute="trailing" constant="8" id="N4E-MB-UHB"/>
+                                                                            <constraint firstItem="UX8-iM-mvM" firstAttribute="leading" secondItem="LYZ-47-tMs" secondAttribute="leading" constant="16" id="OgQ-rF-7F2"/>
+                                                                            <constraint firstAttribute="height" constant="75" id="QeB-iw-Bg7"/>
+                                                                            <constraint firstAttribute="trailing" secondItem="Ipj-Qb-dFT" secondAttribute="trailing" id="Y5O-H4-6Jc"/>
+                                                                            <constraint firstAttribute="height" relation="lessThanOrEqual" constant="75" id="fCS-KA-D16"/>
+                                                                            <constraint firstAttribute="trailing" secondItem="BCh-oh-AhT" secondAttribute="trailing" constant="16" id="grE-kF-nYW"/>
+                                                                            <constraint firstItem="Ipj-Qb-dFT" firstAttribute="leading" secondItem="LYZ-47-tMs" secondAttribute="leading" constant="16" id="njH-4v-BkU"/>
+                                                                            <constraint firstItem="UX8-iM-mvM" firstAttribute="top" secondItem="Ipj-Qb-dFT" secondAttribute="bottom" constant="10.5" id="s8A-Sf-XZP"/>
+                                                                        </constraints>
+                                                                    </view>
                                                                 </subviews>
                                                                 <constraints>
                                                                     <constraint firstItem="HkK-PN-lqS" firstAttribute="width" secondItem="INe-A6-aE8" secondAttribute="width" id="1xl-gu-OSk"/>
                                                                     <constraint firstItem="3Ap-lI-T3q" firstAttribute="width" secondItem="INe-A6-aE8" secondAttribute="width" id="7nN-3U-fnv"/>
                                                                     <constraint firstItem="2Qr-vR-7XY" firstAttribute="width" secondItem="INe-A6-aE8" secondAttribute="width" id="COT-FU-njr"/>
+                                                                    <constraint firstItem="LYZ-47-tMs" firstAttribute="width" secondItem="INe-A6-aE8" secondAttribute="width" id="FPv-kU-o5c"/>
                                                                     <constraint firstItem="TKq-5f-vww" firstAttribute="width" secondItem="INe-A6-aE8" secondAttribute="width" id="KAf-j2-aNc"/>
                                                                     <constraint firstItem="rrZ-eW-qVi" firstAttribute="width" secondItem="INe-A6-aE8" secondAttribute="width" id="LWl-Hq-YaF"/>
                                                                     <constraint firstItem="DRO-9H-eDq" firstAttribute="width" secondItem="INe-A6-aE8" secondAttribute="width" id="pN0-NG-W7L"/>
@@ -733,6 +789,8 @@
                     </view>
                     <navigationItem key="navigationItem" id="c78-Xc-PQ5"/>
                     <connections>
+                        <outlet property="mixTxChangeSummary" destination="cd0-w2-gb2" id="pxB-bn-3Sh"/>
+                        <outlet property="mixTxChangeSwitch" destination="BCh-oh-AhT" id="RsK-56-lOh"/>
                         <outlet property="mixedAccountBranch" destination="4UL-Ur-qDb" id="lbe-g7-TdV"/>
                         <outlet property="mixedAccountLabel" destination="YPA-lh-ntY" id="tbN-Hz-MHR"/>
                         <outlet property="mixedBalance" destination="qNx-so-qhl" id="ux6-bK-ddg"/>
@@ -758,27 +816,27 @@
             <objects>
                 <viewController storyboardIdentifier="PrivacySetupTypeViewController" automaticallyAdjustsScrollViewInsets="NO" id="YFH-6t-Z4b" customClass="PrivacySetupTypeViewController" customModule="Decred_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="BYv-ow-PPX">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Mq9-YB-HNE">
-                                <rect key="frame" x="16" y="27" width="17" height="22"/>
+                                <rect key="frame" x="16" y="73" width="17" height="22"/>
                                 <state key="normal" image="left-arrow"/>
                                 <connections>
                                     <action selector="dismissView:" destination="YFH-6t-Z4b" eventType="touchUpInside" id="cVz-iP-MUD"/>
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VQL-7L-a2b">
-                                <rect key="frame" x="53" y="16" width="531" height="44"/>
+                                <rect key="frame" x="53" y="60" width="345" height="47.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Set up needed accounts" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YNe-QC-nYM">
-                                        <rect key="frame" x="0.0" y="0.0" width="531" height="23.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="345" height="25.5"/>
                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="20"/>
                                         <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="mywallet" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LxI-iH-E0M">
-                                        <rect key="frame" x="0.0" y="27.5" width="531" height="16.5"/>
+                                        <rect key="frame" x="0.0" y="29.5" width="345" height="18"/>
                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                         <color key="textColor" red="0.34901960780000002" green="0.42745098040000001" blue="0.50588235290000005" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
@@ -796,10 +854,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OBF-P0-DtZ" customClass="RoundedView" customModule="Decred_Wallet" customModuleProvider="target">
-                                <rect key="frame" x="8" y="488" width="584" height="96"/>
+                                <rect key="frame" x="8" y="784" width="398" height="96"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qjM-R7-UvV" customClass="Button" customModule="Decred_Wallet" customModuleProvider="target">
-                                        <rect key="frame" x="552" y="36" width="24" height="24"/>
+                                        <rect key="frame" x="366" y="36" width="24" height="24"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="24" id="52q-54-UTn"/>
@@ -832,16 +890,16 @@
                                         </constraints>
                                     </imageView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xne-6C-X3w">
-                                        <rect key="frame" x="50" y="16" width="490" height="64"/>
+                                        <rect key="frame" x="50" y="16" width="304" height="64"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Manual setup" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="43k-Kf-uoh">
-                                                <rect key="frame" x="0.0" y="0.0" width="490" height="21"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="304" height="23"/>
                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="18"/>
                                                 <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="For wallets that have enabled privacy before." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sox-SE-b7y">
-                                                <rect key="frame" x="0.0" y="27" width="490" height="16.5"/>
+                                                <rect key="frame" x="0.0" y="29" width="304" height="18"/>
                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                 <color key="textColor" red="0.23921568630000001" green="0.34509803919999998" blue="0.45098039220000002" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -886,10 +944,10 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GKO-QV-wpO" customClass="RoundedView" customModule="Decred_Wallet" customModuleProvider="target">
-                                <rect key="frame" x="8" y="384" width="584" height="96"/>
+                                <rect key="frame" x="8" y="680" width="398" height="96"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ROd-rd-67z" customClass="Button" customModule="Decred_Wallet" customModuleProvider="target">
-                                        <rect key="frame" x="552" y="36" width="24" height="24"/>
+                                        <rect key="frame" x="366" y="36" width="24" height="24"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="24" id="cUm-rQ-dsf"/>
@@ -919,16 +977,16 @@
                                         </constraints>
                                     </imageView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PPn-r6-xHF">
-                                        <rect key="frame" x="50" y="16" width="490" height="64"/>
+                                        <rect key="frame" x="50" y="16" width="304" height="64"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Auto setup" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DM6-GV-WgF">
-                                                <rect key="frame" x="0.0" y="0.0" width="490" height="21"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="304" height="23"/>
                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="18"/>
                                                 <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unmixed account will be the change handling account." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FSC-vf-97U">
-                                                <rect key="frame" x="0.0" y="27" width="490" height="16.5"/>
+                                                <rect key="frame" x="0.0" y="29" width="304" height="35.5"/>
                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                 <color key="textColor" red="0.23921568630000001" green="0.34509803919999998" blue="0.45098039220000002" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -973,7 +1031,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unmixed account will be the change handling account." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L4s-cH-Uzh">
-                                <rect key="frame" x="38" y="149" width="538" height="19"/>
+                                <rect key="frame" x="38" y="219.5" width="352" height="40.5"/>
                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                 <color key="textColor" red="0.23921568630000001" green="0.34509803919999998" blue="0.45098039220000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -982,13 +1040,13 @@
                                 </userDefinedRuntimeAttributes>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Mixed account will be the outbound spending account." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2dY-XK-tSL">
-                                <rect key="frame" x="38" y="114" width="538" height="19"/>
+                                <rect key="frame" x="38" y="163" width="352" height="40.5"/>
                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                 <color key="textColor" red="0.23921568630000001" green="0.34509803919999998" blue="0.45098039220000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Two dedicated accounts will be set up to use the mixer:" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C9a-y6-x8Q">
-                                <rect key="frame" x="24" y="79" width="552" height="19"/>
+                                <rect key="frame" x="24" y="126.5" width="366" height="20.5"/>
                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                 <color key="textColor" red="0.23921568627450979" green="0.34509803921568627" blue="0.45098039215686275" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -1037,21 +1095,21 @@
             <objects>
                 <viewController storyboardIdentifier="PrivacyManualSetupViewController" automaticallyAdjustsScrollViewInsets="NO" id="ZTY-JF-4EY" customClass="PrivacyManualSetupViewController" customModule="Decred_Wallet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="02w-ud-9hs">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jh9-Wu-Jnh">
-                                <rect key="frame" x="16" y="37.5" width="17" height="22"/>
+                                <rect key="frame" x="16" y="37.5" width="16.5" height="22"/>
                                 <state key="normal" image="left-arrow"/>
                                 <connections>
                                     <action selector="dismissView:" destination="ZTY-JF-4EY" eventType="touchUpInside" id="Y9x-Eo-t7o"/>
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pfm-FT-pyp">
-                                <rect key="frame" x="53" y="16" width="531" height="65"/>
+                                <rect key="frame" x="52.5" y="16" width="345.5" height="65"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Manual Setup" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hKI-Bx-Sh1">
-                                        <rect key="frame" x="0.0" y="0.0" width="531" height="23.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="345.5" height="25.5"/>
                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="20"/>
                                         <color key="textColor" red="0.035294117649999998" green="0.078431372550000003" blue="0.25098039220000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -1060,7 +1118,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="mywallet" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wov-X4-mJT">
-                                        <rect key="frame" x="0.0" y="27.5" width="55.5" height="16.5"/>
+                                        <rect key="frame" x="0.0" y="29.5" width="54" height="18"/>
                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                         <color key="textColor" red="0.34901960780000002" green="0.42745098040000001" blue="0.50588235290000005" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
@@ -1076,19 +1134,19 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="23O-YZ-Qfw" customClass="RoundedView" customModule="Decred_Wallet" customModuleProvider="target">
-                                <rect key="frame" x="8" y="89" width="584" height="112"/>
+                                <rect key="frame" x="8" y="89" width="398" height="112"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="gHe-5E-dP9">
-                                        <rect key="frame" x="4" y="3" width="576" height="106"/>
+                                        <rect key="frame" x="4" y="3" width="390" height="106"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Mixed Account" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9mm-Tf-WOO">
-                                                <rect key="frame" x="16" y="0.0" width="544" height="16.5"/>
+                                                <rect key="frame" x="16" y="0.0" width="358" height="18"/>
                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                 <color key="textColor" red="0.34901960780000002" green="0.42745098040000001" blue="0.50588235290000005" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dtn-pa-8MK" customClass="WalletAccountView" customModule="Decred_Wallet" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="16.5" width="576" height="89.5"/>
+                                                <rect key="frame" x="0.0" y="18" width="390" height="88"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             </view>
                                         </subviews>
@@ -1129,19 +1187,19 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="op5-gv-ZUw" customClass="RoundedView" customModule="Decred_Wallet" customModuleProvider="target">
-                                <rect key="frame" x="8" y="209" width="584" height="112"/>
+                                <rect key="frame" x="8" y="209" width="398" height="112"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="bdK-IW-EvH">
-                                        <rect key="frame" x="4" y="3" width="576" height="106"/>
+                                        <rect key="frame" x="4" y="3" width="390" height="106"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unmixed Account" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hbn-sk-Y37">
-                                                <rect key="frame" x="16" y="0.0" width="544" height="16.5"/>
+                                                <rect key="frame" x="16" y="0.0" width="358" height="18"/>
                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                 <color key="textColor" red="0.34901960784313724" green="0.42745098039215684" blue="0.50588235294117645" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="piF-wJ-hQd" customClass="WalletAccountView" customModule="Decred_Wallet" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="16.5" width="576" height="89.5"/>
+                                                <rect key="frame" x="0.0" y="18" width="390" height="88"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             </view>
                                         </subviews>
@@ -1182,7 +1240,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Make sure to select the corresponding accounts to the previous setup. Failing to do so could damage wallet privacy." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="THn-oT-tEQ">
-                                <rect key="frame" x="52" y="337" width="532" height="37.5"/>
+                                <rect key="frame" x="52" y="337" width="346" height="60.5"/>
                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="16"/>
                                 <color key="textColor" red="0.23921568630000001" green="0.34509803919999998" blue="0.45098039220000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -1191,10 +1249,10 @@
                                 </userDefinedRuntimeAttributes>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="e3e-Zj-wSm">
-                                <rect key="frame" x="0.0" y="465" width="600" height="115"/>
+                                <rect key="frame" x="0.0" y="727" width="414" height="115"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zrj-Lb-M0h" customClass="Button" customModule="Decred_Wallet" customModuleProvider="target">
-                                        <rect key="frame" x="24" y="16" width="552" height="48"/>
+                                        <rect key="frame" x="24" y="16" width="366" height="48"/>
                                         <color key="backgroundColor" red="0.76862745098039209" green="0.79607843137254897" blue="0.82352941176470584" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="48" id="bkJ-LF-OHc"/>
@@ -1278,6 +1336,20 @@
             <point key="canvasLocation" x="216" y="668"/>
         </scene>
     </scenes>
+    <designables>
+        <designable name="ROd-rd-67z">
+            <size key="intrinsicContentSize" width="192" height="24"/>
+        </designable>
+        <designable name="Zrj-Lb-M0h">
+            <size key="intrinsicContentSize" width="44" height="35"/>
+        </designable>
+        <designable name="ayu-ew-FJN">
+            <size key="intrinsicContentSize" width="156" height="35"/>
+        </designable>
+        <designable name="qjM-R7-UvV">
+            <size key="intrinsicContentSize" width="192" height="24"/>
+        </designable>
+    </designables>
     <resources>
         <image name="ic_alert" width="16" height="16"/>
         <image name="ic_arrow_next" width="24" height="24"/>

--- a/Decred Wallet/Features/Privacy/PrivacyViewController.swift
+++ b/Decred Wallet/Features/Privacy/PrivacyViewController.swift
@@ -87,12 +87,10 @@ class PrivacyViewController: UIViewController {
         }
     }
     
-    
     @IBAction func mixChangeSwitch(_ sender: Any) {
         wallet.setBoolConfigValueForKey(DcrlibwalletAccountMixerMixTxChange, value: self.mixTxChangeSwitch.isOn)
         self.setMixTxChangeSummary()
     }
-    
     
     @IBAction func privacyInfo(_ sender: Any) {
         SimpleAlertDialog.show(sender: self,
@@ -101,6 +99,7 @@ class PrivacyViewController: UIViewController {
                                   okButtonText: LocalizedStrings.gotIt,
                                   callback: nil)
     }
+    
     @IBAction func dismissView(_ sender: Any) {
         self.navigationController?.popToRootViewController(animated: true)
     }
@@ -126,8 +125,6 @@ class PrivacyViewController: UIViewController {
             self.showWarningAndStartMixer()
         }
     }
-    
-    
     
     func stopAccountMixer() {
          do {

--- a/Decred Wallet/Features/Privacy/PrivacyViewController.swift
+++ b/Decred Wallet/Features/Privacy/PrivacyViewController.swift
@@ -21,9 +21,10 @@ class PrivacyViewController: UIViewController {
     @IBOutlet weak var shuffleServer: UILabel!
     @IBOutlet weak var shufflePort: UILabel!
     @IBOutlet weak var mixerSwitch: UISwitch!
-    @IBOutlet weak var spendUnmixedSwitch: UISwitch!
+    @IBOutlet weak var mixTxChangeSwitch: UISwitch!
     @IBOutlet weak var mixerStatusIcon: UIImageView!
     @IBOutlet weak var mixingInfo: UILabel!
+    @IBOutlet weak var mixTxChangeSummary: UILabel!
     
     @IBOutlet weak var mixerDetailViewConst: NSLayoutConstraint!
     @IBOutlet weak var mixerDropdownArrow: UIImageView!
@@ -40,10 +41,14 @@ class PrivacyViewController: UIViewController {
         let txNotificationListener = self as DcrlibwalletTxAndBlockNotificationListenerProtocol
         try? WalletLoader.shared.multiWallet.add(txNotificationListener, uniqueIdentifier: "\(self)")
         
-        WalletLoader.shared.multiWallet.setAccountMixerNotification(self)
+        let accountMixerNotification = self as DcrlibwalletAccountMixerNotificationListenerProtocol
+        try? WalletLoader.shared.multiWallet.add(accountMixerNotification, uniqueIdentifier: "\(self)")
         
         self.mixedAccountNumber = wallet.readIntConfigValue(forKey: DcrlibwalletAccountMixerMixedAccount, defaultValue: -1)
         self.unmixedAccountNumber = wallet.readIntConfigValue(forKey: DcrlibwalletAccountMixerUnmixedAccount, defaultValue: -1)
+        
+        self.mixTxChangeSwitch.isOn = wallet.readBoolConfigValue(forKey: DcrlibwalletAccountMixerMixTxChange, defaultValue: false)
+        self.setMixTxChangeSummary()
         
         self.updateMixerSettingsInfo()
         
@@ -73,6 +78,21 @@ class PrivacyViewController: UIViewController {
         }
         self.shufflePort.text = shufflePort
     }
+    
+    func setMixTxChangeSummary() {
+        if (self.mixTxChangeSwitch.isOn) {
+            self.mixTxChangeSummary.text = LocalizedStrings.mixTxChangeSummaryEnabled
+        } else {
+            self.mixTxChangeSummary.text = LocalizedStrings.mixTxChangeSummaryDisabled
+        }
+    }
+    
+    
+    @IBAction func mixChangeSwitch(_ sender: Any) {
+        wallet.setBoolConfigValueForKey(DcrlibwalletAccountMixerMixTxChange, value: self.mixTxChangeSwitch.isOn)
+        self.setMixTxChangeSummary()
+    }
+    
     
     @IBAction func privacyInfo(_ sender: Any) {
         SimpleAlertDialog.show(sender: self,
@@ -106,6 +126,8 @@ class PrivacyViewController: UIViewController {
             self.showWarningAndStartMixer()
         }
     }
+    
+    
     
     func stopAccountMixer() {
          do {

--- a/Decred Wallet/Features/Send/Send.storyboard
+++ b/Decred Wallet/Features/Send/Send.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -83,7 +83,7 @@
                                 </constraints>
                             </view>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1VY-fw-ObN">
-                                <rect key="frame" x="0.0" y="100" width="414" height="601"/>
+                                <rect key="frame" x="0.0" y="100" width="414" height="568.5"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="H3C-42-Oka">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="877.5"/>
@@ -628,10 +628,10 @@
                                 </constraints>
                             </scrollView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="T9I-3F-cJf">
-                                <rect key="frame" x="0.0" y="709" width="414" height="153"/>
+                                <rect key="frame" x="0.0" y="676.5" width="414" height="185.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Total cost" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eB8-kv-pro">
-                                        <rect key="frame" x="16" y="17.5" width="56" height="18"/>
+                                        <rect key="frame" x="16" y="17" width="56" height="18"/>
                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                         <color key="textColor" red="0.34901960780000002" green="0.42745098040000001" blue="0.50588235290000005" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
@@ -646,7 +646,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Balance after send" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Uwo-dA-rVW">
-                                        <rect key="frame" x="16" y="54" width="107.5" height="18"/>
+                                        <rect key="frame" x="16" y="53.5" width="107.5" height="18"/>
                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                         <color key="textColor" red="0.34901960780000002" green="0.42745098040000001" blue="0.50588235290000005" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
@@ -661,7 +661,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uE2-R8-tCb" customClass="Button" customModule="Decred_Wallet" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="89" width="382" height="48"/>
+                                        <rect key="frame" x="16" y="121.5" width="382" height="48"/>
                                         <color key="backgroundColor" red="0.15686274510000001" green="0.43921568630000002" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                         <inset key="contentEdgeInsets" minX="15" minY="15" maxX="15" maxY="15"/>
                                         <state key="normal" title="Next">
@@ -686,18 +686,27 @@
                                             <action selector="nextButtonTapped:" destination="QI0-Sp-Mco" eventType="touchUpInside" id="UFJ-iU-InN"/>
                                         </connections>
                                     </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Change of 1.64344 DCR will return to 'default'" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oQI-LG-nQW">
+                                        <rect key="frame" x="16" y="87.5" width="262.5" height="18"/>
+                                        <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
+                                        <color key="textColor" red="0.34901960780000002" green="0.42745098040000001" blue="0.50588235290000005" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstItem="uE2-R8-tCb" firstAttribute="leading" secondItem="T9I-3F-cJf" secondAttribute="leading" constant="16" id="BtD-eD-Ofq"/>
                                     <constraint firstItem="0VB-8U-kh0" firstAttribute="top" secondItem="NX9-am-HqU" secondAttribute="bottom" constant="16" id="CQ6-R7-tgs"/>
-                                    <constraint firstItem="uE2-R8-tCb" firstAttribute="top" secondItem="0VB-8U-kh0" secondAttribute="bottom" constant="16" id="FXJ-YO-HwQ"/>
                                     <constraint firstAttribute="trailing" secondItem="0VB-8U-kh0" secondAttribute="trailing" constant="16" id="JX1-PN-tRp"/>
                                     <constraint firstItem="Uwo-dA-rVW" firstAttribute="leading" secondItem="T9I-3F-cJf" secondAttribute="leading" constant="16" id="NFo-jf-4FZ"/>
                                     <constraint firstAttribute="trailing" secondItem="NX9-am-HqU" secondAttribute="trailing" constant="16" id="Oe5-Y0-gxW"/>
+                                    <constraint firstItem="uE2-R8-tCb" firstAttribute="top" secondItem="oQI-LG-nQW" secondAttribute="bottom" constant="16" id="PTS-SX-Vzs"/>
                                     <constraint firstAttribute="bottom" secondItem="uE2-R8-tCb" secondAttribute="bottom" constant="16" id="UyP-A5-Q87"/>
                                     <constraint firstItem="NX9-am-HqU" firstAttribute="top" secondItem="T9I-3F-cJf" secondAttribute="top" constant="16" id="aeh-wA-uJH"/>
                                     <constraint firstItem="eB8-kv-pro" firstAttribute="leading" secondItem="T9I-3F-cJf" secondAttribute="leading" constant="16" id="eq3-Xa-WzD"/>
+                                    <constraint firstItem="oQI-LG-nQW" firstAttribute="top" secondItem="Uwo-dA-rVW" secondAttribute="bottom" constant="16" id="gYy-WI-aAf"/>
+                                    <constraint firstItem="oQI-LG-nQW" firstAttribute="leading" secondItem="T9I-3F-cJf" secondAttribute="leading" constant="16" id="leW-gq-zca"/>
+                                    <constraint firstItem="uE2-R8-tCb" firstAttribute="top" relation="greaterThanOrEqual" secondItem="Uwo-dA-rVW" secondAttribute="bottom" constant="16" id="nna-On-4wC"/>
                                     <constraint firstAttribute="trailing" secondItem="uE2-R8-tCb" secondAttribute="trailing" constant="16" id="tRW-2u-JlM"/>
                                     <constraint firstItem="eB8-kv-pro" firstAttribute="centerY" secondItem="NX9-am-HqU" secondAttribute="centerY" id="vBB-fD-Oo5"/>
                                     <constraint firstItem="Uwo-dA-rVW" firstAttribute="centerY" secondItem="0VB-8U-kh0" secondAttribute="centerY" id="vmw-DI-KVv"/>
@@ -724,10 +733,13 @@
                         <outlet property="amountContainerView" destination="2rv-Cb-tiy" id="xY6-11-LXi"/>
                         <outlet property="amountTextField" destination="R2D-m0-pos" id="WIP-La-gkI"/>
                         <outlet property="balanceAfterSendingLabel" destination="0VB-8U-kh0" id="Aad-RH-1oj"/>
+                        <outlet property="changeSummary" destination="oQI-LG-nQW" id="mof-M5-Uvb"/>
                         <outlet property="destinationAccountView" destination="vka-UC-gd6" id="tEl-9a-cFf"/>
                         <outlet property="destinationAddressTextField" destination="JDR-oq-YJC" id="vQR-vl-vqZ"/>
                         <outlet property="feeRateLabel" destination="BHd-xR-fIs" id="zg1-3p-ugd"/>
                         <outlet property="invalidDestinationAddressLabel" destination="19H-1W-F1v" id="cB8-xu-yfn"/>
+                        <outlet property="maxBtn" destination="bPH-60-lge" id="m2X-n9-haX"/>
+                        <outlet property="nextBtnToChangeTop" destination="PTS-SX-Vzs" id="eoD-H1-8qA"/>
                         <outlet property="nextButton" destination="uE2-R8-tCb" id="5Ah-aS-Waq"/>
                         <outlet property="notEnoughFundsLabel" destination="vKM-60-zWN" id="gHv-kh-bXz"/>
                         <outlet property="processingTimeLabel" destination="O4X-9A-RKk" id="g8Y-IC-HhG"/>
@@ -762,7 +774,7 @@
                     </connections>
                 </tapGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="-614" y="-252"/>
+            <point key="canvasLocation" x="-614.49275362318849" y="-252.45535714285714"/>
         </scene>
         <!--Confirm To Send Fund View Controller-->
         <scene sceneID="ztT-Wn-CO5">

--- a/Decred Wallet/Features/Send/SendViewController.swift
+++ b/Decred Wallet/Features/Send/SendViewController.swift
@@ -172,6 +172,8 @@ class SendViewController: UIViewController {
         
         if self.sendMax {
             self.calculateAndSetMaxSendableAmount()
+        } else {
+            self.amountTextFieldEditingEnded()
         }
     }
 
@@ -557,10 +559,12 @@ extension SendViewController {
         self.totalCostLabel.text = self.parseDCRAmount(totalCost.doubleValue, usdDecimalPlaces: 2)
         
         let selectedAccount = sourceAccountView.selectedAccount
+        let destinationAccount = destinationAccountView.selectedAccount
         
         if let wallet = WalletLoader.shared.multiWallet.wallet(withID: selectedAccount!.walletID) {
             let sourceAccountNumber = selectedAccount?.number
-            if (!self.sendMax && (wallet.accountMixerMixChange() || wallet.mixedAccountNumber() == sourceAccountNumber) && wallet.unmixedAccountNumber() != sourceAccountNumber && change ?? 0 > 0) {
+            let destinationAccountNumber = destinationAccount?.number
+            if (!self.sendMax && (wallet.accountMixerMixChange() || wallet.mixedAccountNumber() == sourceAccountNumber) && wallet.unmixedAccountNumber() != sourceAccountNumber && wallet.unmixedAccountNumber() != destinationAccountNumber && change ?? 0 > 0) {
                 balanceAfterSending = NSDecimalNumber(value: sourceAccountBalance).subtracting(totalCost).subtracting(NSDecimalNumber(value: txFeeAndSize.change!.dcrValue))
                 var error: NSError?
                 let changeAccountName = wallet.accountName(wallet.unmixedAccountNumber(), error: &error)

--- a/Decred Wallet/Features/Send/SendViewController.swift
+++ b/Decred Wallet/Features/Send/SendViewController.swift
@@ -61,13 +61,15 @@ class SendViewController: UIViewController {
     @IBOutlet var balanceAfterSendingLabel: UILabel!
     @IBOutlet var nextButton: UIButton!
     @IBOutlet weak var swapButton: UIButton!
+    @IBOutlet weak var maxBtn: UIButton!
     
     @IBOutlet weak var scrollViewBottomConstraint: NSLayoutConstraint!
     
+    @IBOutlet weak var changeSummary: UILabel!
+    @IBOutlet weak var nextBtnToChangeTop: NSLayoutConstraint!
     private lazy var qrImageScanner = QRImageScanner()
     
     var exchangeRate: NSDecimalNumber?
-    var sendMax: Bool = false
     var dcrAmountUnit: Bool = true
     var exchangeValue: NSDecimalNumber?
     var amountValue: NSDecimalNumber?
@@ -76,6 +78,12 @@ class SendViewController: UIViewController {
         let amountCrudeText = self.amountTextField.text
         let validTextAmountString = amountCrudeText?.dropLast(4) ?? ""
         return String(validTextAmountString)
+    }
+    
+    var sendMax: Bool = false {
+        didSet {
+            maxBtn.backgroundColor = sendMax ? UIColor.appColors.lightBlue : UIColor.appColors.bluishGray
+        }
     }
     
     override func viewDidLoad() {
@@ -523,6 +531,8 @@ extension SendViewController {
             
             self.totalCostLabel.text = self.parseDCRAmount(0, usdDecimalPlaces: 2)
             self.balanceAfterSendingLabel.text = "0 DCR"
+            self.changeSummary.text = ""
+            self.nextBtnToChangeTop.constant = 0
             
             self.nextButton.isEnabled = false
             return
@@ -541,10 +551,34 @@ extension SendViewController {
         let sourceAccountBalance = self.sourceAccountView.selectedAccount?.balance!.dcrSpendable ?? 0
         
         let totalCost = NSDecimalNumber(value: sendAmountDcr + txFeeAndSize.fee!.dcrValue)
-        let balanceAfterSending = NSDecimalNumber(value: sourceAccountBalance).subtracting(totalCost)
+        let change = txFeeAndSize.change?.dcrValue
+        var balanceAfterSending = NSDecimalNumber(value: sourceAccountBalance).subtracting(totalCost)
         
         self.totalCostLabel.text = self.parseDCRAmount(totalCost.doubleValue, usdDecimalPlaces: 2)
-        self.balanceAfterSendingLabel.text = "\(balanceAfterSending.round(8).formattedWithSeparator) DCR"
+        
+        let selectedAccount = sourceAccountView.selectedAccount
+        
+        if let wallet = WalletLoader.shared.multiWallet.wallet(withID: selectedAccount!.walletID) {
+            let sourceAccountNumber = selectedAccount?.number
+            if (!self.sendMax && (wallet.accountMixerMixChange() || wallet.mixedAccountNumber() == sourceAccountNumber) && wallet.unmixedAccountNumber() != sourceAccountNumber && change ?? 0 > 0) {
+                balanceAfterSending = NSDecimalNumber(value: sourceAccountBalance).subtracting(totalCost).subtracting(NSDecimalNumber(value: txFeeAndSize.change!.dcrValue))
+                var error: NSError?
+                let changeAccountName = wallet.accountName(wallet.unmixedAccountNumber(), error: &error)
+                if let actualError = error {
+                    self.changeSummary.text = ""
+                    self.nextBtnToChangeTop.constant = 0
+                    Utils.showBanner(in: self.view, type: .error, text: actualError.localizedDescription)
+                } else {
+                    self.changeSummary.text = "change of \(txFeeAndSize.change!.dcrValue) will be sent to \(changeAccountName)"
+                    self.nextBtnToChangeTop.constant = 16
+                }
+            } else {
+                balanceAfterSending = NSDecimalNumber(value: sourceAccountBalance).subtracting(totalCost)
+                self.changeSummary.text = ""
+                self.nextBtnToChangeTop.constant = 0
+            }
+            self.balanceAfterSendingLabel.text = "\(balanceAfterSending.round(8).formattedWithSeparator) DCR"
+        }
         
         self.nextButton.isEnabled = true
     }

--- a/Decred Wallet/Features/Send/SendViewController.swift
+++ b/Decred Wallet/Features/Send/SendViewController.swift
@@ -569,7 +569,8 @@ extension SendViewController {
                     self.nextBtnToChangeTop.constant = 0
                     Utils.showBanner(in: self.view, type: .error, text: actualError.localizedDescription)
                 } else {
-                    self.changeSummary.text = "change of \(txFeeAndSize.change!.dcrValue) will be sent to \(changeAccountName)"
+                    //self.changeSummary.text = "change of \(txFeeAndSize.change!.dcrValue) will be sent to \(changeAccountName)"
+                    self.changeSummary.attributedText = String(format: LocalizedStrings.changeSummary, txFeeAndSize.change!.dcrValue.description, changeAccountName).htmlToAttributedString
                     self.nextBtnToChangeTop.constant = 16
                 }
             } else {

--- a/Decred Wallet/Utils/LocalizedStrings.swift
+++ b/Decred Wallet/Utils/LocalizedStrings.swift
@@ -551,4 +551,7 @@ struct LocalizedStrings {
     static let mix = NSLocalizedString("mix", comment: "")
     static let privacy = NSLocalizedString("privacy", comment: "")
     static let newLabel = NSLocalizedString("newLabel", comment: "")
+    static let mixTxChangeSummaryEnabled = NSLocalizedString("mixTxChangeSummaryEnabled", comment: "")
+    static let mixTxChangeSummaryDisabled = NSLocalizedString("mixTxChangeSummaryDisabled", comment: "")
+    static let mixTxChange = NSLocalizedString("mixTxChange", comment: "")
 }

--- a/Decred Wallet/Utils/LocalizedStrings.swift
+++ b/Decred Wallet/Utils/LocalizedStrings.swift
@@ -554,4 +554,5 @@ struct LocalizedStrings {
     static let mixTxChangeSummaryEnabled = NSLocalizedString("mixTxChangeSummaryEnabled", comment: "")
     static let mixTxChangeSummaryDisabled = NSLocalizedString("mixTxChangeSummaryDisabled", comment: "")
     static let mixTxChange = NSLocalizedString("mixTxChange", comment: "")
+    static let changeSummary = NSLocalizedString("changeSummary", comment: "")
 }

--- a/Decred Wallet/en.lproj/Localizable.strings
+++ b/Decred Wallet/en.lproj/Localizable.strings
@@ -597,3 +597,4 @@
 "mixTxChangeSummaryEnabled" = "Change on transactions from all accounts will go to unmixed";
 "mixTxChangeSummaryDisabled" = "Change on transactions from mixed will go to unmixed";
 "mixTxChange" = "Mix change";
+"changeSummary" = "<span style=\"font-family: 'SourceSansPro-Regular'; font-size: 14px; color: #596D81\">Change of <b>%@ DCR</b> will return to \'<b>%@</b>\'";

--- a/Decred Wallet/en.lproj/Localizable.strings
+++ b/Decred Wallet/en.lproj/Localizable.strings
@@ -594,3 +594,6 @@
 "mixed" = "Mixed";
 "mix" = "Mix";
 "newLabel" = "NEW";
+"mixTxChangeSummaryEnabled" = "Change on transactions from all accounts will go to unmixed";
+"mixTxChangeSummaryDisabled" = "Change on transactions from mixed will go to unmixed";
+"mixTxChange" = "Mix change";

--- a/Decred Wallet/es.lproj/Localizable.strings
+++ b/Decred Wallet/es.lproj/Localizable.strings
@@ -594,3 +594,6 @@
 "privacy" = "Privacy";
 "mix" = "Mix";
 "newLabel" = "NEW";
+"mixTxChangeSummaryEnabled" = "Change on transactions from all accounts will go to unmixed";
+"mixTxChangeSummaryDisabled" = "Change on transactions from mixed will go to unmixed";
+"mixTxChange" = "Mix change";

--- a/Decred Wallet/es.lproj/Localizable.strings
+++ b/Decred Wallet/es.lproj/Localizable.strings
@@ -597,3 +597,4 @@
 "mixTxChangeSummaryEnabled" = "Change on transactions from all accounts will go to unmixed";
 "mixTxChangeSummaryDisabled" = "Change on transactions from mixed will go to unmixed";
 "mixTxChange" = "Mix change";
+"changeSummary" = "<span style=\"font-family: 'SourceSansPro-Regular'; font-size: 14px; color: #596D81\">Change of <b>%@ DCR</b> will return to \'<b>%@</b>\'";

--- a/Decred Wallet/fr.lproj/Localizable.strings
+++ b/Decred Wallet/fr.lproj/Localizable.strings
@@ -594,3 +594,6 @@
 "privacy" = "Privacy";
 "mix" = "Mix";
 "newLabel" = "NEW";
+"mixTxChangeSummaryEnabled" = "Change on transactions from all accounts will go to unmixed";
+"mixTxChangeSummaryDisabled" = "Change on transactions from mixed will go to unmixed";
+"mixTxChange" = "Mix change";

--- a/Decred Wallet/fr.lproj/Localizable.strings
+++ b/Decred Wallet/fr.lproj/Localizable.strings
@@ -597,3 +597,4 @@
 "mixTxChangeSummaryEnabled" = "Change on transactions from all accounts will go to unmixed";
 "mixTxChangeSummaryDisabled" = "Change on transactions from mixed will go to unmixed";
 "mixTxChange" = "Mix change";
+"changeSummary" = "<span style=\"font-family: 'SourceSansPro-Regular'; font-size: 14px; color: #596D81\">Change of <b>%@ DCR</b> will return to \'<b>%@</b>\'";

--- a/Decred Wallet/pl.lproj/Localizable.strings
+++ b/Decred Wallet/pl.lproj/Localizable.strings
@@ -594,3 +594,6 @@
 "privacy" = "Privacy";
 "mix" = "Mix";
 "newLabel" = "NEW";
+"mixTxChangeSummaryEnabled" = "Change on transactions from all accounts will go to unmixed";
+"mixTxChangeSummaryDisabled" = "Change on transactions from mixed will go to unmixed";
+"mixTxChange" = "Mix change";

--- a/Decred Wallet/pl.lproj/Localizable.strings
+++ b/Decred Wallet/pl.lproj/Localizable.strings
@@ -597,3 +597,4 @@
 "mixTxChangeSummaryEnabled" = "Change on transactions from all accounts will go to unmixed";
 "mixTxChangeSummaryDisabled" = "Change on transactions from mixed will go to unmixed";
 "mixTxChange" = "Mix change";
+"changeSummary" = "<span style=\"font-family: 'SourceSansPro-Regular'; font-size: 14px; color: #596D81\">Change of <b>%@ DCR</b> will return to \'<b>%@</b>\'";

--- a/Decred Wallet/pt-BR.lproj/Localizable.strings
+++ b/Decred Wallet/pt-BR.lproj/Localizable.strings
@@ -594,3 +594,6 @@
 "privacy" = "Privacy";
 "mix" = "Mix";
 "newLabel" = "NEW";
+"mixTxChangeSummaryEnabled" = "Change on transactions from all accounts will go to unmixed";
+"mixTxChangeSummaryDisabled" = "Change on transactions from mixed will go to unmixed";
+"mixTxChange" = "Mix change";

--- a/Decred Wallet/pt-BR.lproj/Localizable.strings
+++ b/Decred Wallet/pt-BR.lproj/Localizable.strings
@@ -597,3 +597,4 @@
 "mixTxChangeSummaryEnabled" = "Change on transactions from all accounts will go to unmixed";
 "mixTxChangeSummaryDisabled" = "Change on transactions from mixed will go to unmixed";
 "mixTxChange" = "Mix change";
+"changeSummary" = "<span style=\"font-family: 'SourceSansPro-Regular'; font-size: 14px; color: #596D81\">Change of <b>%@ DCR</b> will return to \'<b>%@</b>\'";

--- a/Decred Wallet/ru-RU.lproj/Localizable.strings
+++ b/Decred Wallet/ru-RU.lproj/Localizable.strings
@@ -594,3 +594,6 @@
 "privacy" = "Privacy";
 "mix" = "Mix";
 "newLabel" = "NEW";
+"mixTxChangeSummaryEnabled" = "Change on transactions from all accounts will go to unmixed";
+"mixTxChangeSummaryDisabled" = "Change on transactions from mixed will go to unmixed";
+"mixTxChange" = "Mix change";

--- a/Decred Wallet/ru-RU.lproj/Localizable.strings
+++ b/Decred Wallet/ru-RU.lproj/Localizable.strings
@@ -597,3 +597,4 @@
 "mixTxChangeSummaryEnabled" = "Change on transactions from all accounts will go to unmixed";
 "mixTxChangeSummaryDisabled" = "Change on transactions from mixed will go to unmixed";
 "mixTxChange" = "Mix change";
+"changeSummary" = "<span style=\"font-family: 'SourceSansPro-Regular'; font-size: 14px; color: #596D81\">Change of <b>%@ DCR</b> will return to \'<b>%@</b>\'";

--- a/Decred Wallet/vi.lproj/Localizable.strings
+++ b/Decred Wallet/vi.lproj/Localizable.strings
@@ -594,3 +594,6 @@
 "privacy" = "Privacy";
 "mix" = "Mix";
 "newLabel" = "NEW";
+"mixTxChangeSummaryEnabled" = "Change on transactions from all accounts will go to unmixed";
+"mixTxChangeSummaryDisabled" = "Change on transactions from mixed will go to unmixed";
+"mixTxChange" = "Mix change";

--- a/Decred Wallet/vi.lproj/Localizable.strings
+++ b/Decred Wallet/vi.lproj/Localizable.strings
@@ -597,3 +597,4 @@
 "mixTxChangeSummaryEnabled" = "Change on transactions from all accounts will go to unmixed";
 "mixTxChangeSummaryDisabled" = "Change on transactions from mixed will go to unmixed";
 "mixTxChange" = "Mix change";
+"changeSummary" = "<span style=\"font-family: 'SourceSansPro-Regular'; font-size: 14px; color: #596D81\">Change of <b>%@ DCR</b> will return to \'<b>%@</b>\'";

--- a/Decred Wallet/zh-Hans.lproj/Localizable.strings
+++ b/Decred Wallet/zh-Hans.lproj/Localizable.strings
@@ -594,3 +594,6 @@
 "privacy" = "Privacy";
 "mix" = "Mix";
 "newLabel" = "NEW";
+"mixTxChangeSummaryEnabled" = "Change on transactions from all accounts will go to unmixed";
+"mixTxChangeSummaryDisabled" = "Change on transactions from mixed will go to unmixed";
+"mixTxChange" = "Mix change";

--- a/Decred Wallet/zh-Hans.lproj/Localizable.strings
+++ b/Decred Wallet/zh-Hans.lproj/Localizable.strings
@@ -597,3 +597,4 @@
 "mixTxChangeSummaryEnabled" = "Change on transactions from all accounts will go to unmixed";
 "mixTxChangeSummaryDisabled" = "Change on transactions from mixed will go to unmixed";
 "mixTxChange" = "Mix change";
+"changeSummary" = "<span style=\"font-family: 'SourceSansPro-Regular'; font-size: 14px; color: #596D81\">Change of <b>%@ DCR</b> will return to \'<b>%@</b>\'";


### PR DESCRIPTION
Requires planetdecred/dcrlibwallet#199

- make send max button blue when active

Sending w/ change
<img height ="400" alt="Screenshot 2021-06-17 at 10 19 17" src="https://user-images.githubusercontent.com/794430/122369294-f8e72600-cf55-11eb-8e1e-6bc83f5fbcb1.png">  

Sending w/o change
<img height ="400" alt="Screenshot 2021-06-17 at 10 18 52" src="https://user-images.githubusercontent.com/794430/122369311-fd134380-cf55-11eb-9ffb-fcc0c845b4d7.png">

Sending from other accounts(mix change enabled)
<img height="400" alt="Screenshot 2021-06-17 at 10 21 56" src="https://user-images.githubusercontent.com/794430/122369257-eec52780-cf55-11eb-8219-c62d6cda4856.png">  

Privacy settings
<img height ="400" alt="Screenshot 2021-06-17 at 10 19 50" src="https://user-images.githubusercontent.com/794430/122369272-f389db80-cf55-11eb-9749-6f980ae8d358.png">
