### PR TITLE
safe check wallet initialization on network change

### DIFF
--- a/Decred Wallet/AppDelegate.swift
+++ b/Decred Wallet/AppDelegate.swift
@@ -71,7 +71,9 @@ class AppDelegate: UIResponder {
     @objc func networkChanged(_ notification: Notification) {
         let reachability = notification.object as! Reachability
         print("network changed to \(reachability.connection)")
-        SyncManager.shared.networkChanged(reachability.connection)
+        if WalletLoader.shared.isInitialized {
+            SyncManager.shared.networkChanged(reachability.connection)
+        }
     }
     
     func updateLastActiveTime() {


### PR DESCRIPTION
This PR checks for wallet initialization in AppDelegate before performing the sync networkChanged operation.