### PR TITLE
Update usd balance when wallet balance is updated

### DIFF
--- a/Decred Wallet/Features/Overview/OverviewViewController.swift
+++ b/Decred Wallet/Features/Overview/OverviewViewController.swift
@@ -226,6 +226,9 @@ class OverviewViewController: UIViewController {
         let totalWalletAmount = multiWallet.totalBalance
         let totalAmountRoundedOff = (Decimal(totalWalletAmount) as NSDecimalNumber).round(8)
         self.balanceLabel.attributedText = Utils.getAttributedString(str: "\(totalAmountRoundedOff)", siz: 17.0, TexthexColor: UIColor.appColors.darkBlue)
+        if Settings.currencyConversionOption != .None {
+            displayExchangeRate(self.exchangeRate)
+        }
         self.setMixerStatus()
     }
     


### PR DESCRIPTION
Close #817 

- Reproduce and investigate.
- When wallet balance is updated (after syncing or a new transaction), if user enable currency conversion, we will update usd balance too.