### PR TITLE
fix color theme name in settings

### DIFF
--- a/Decred Wallet/Features/More/More Features/Settings/Settings.storyboard
+++ b/Decred Wallet/Features/More/More Features/Settings/Settings.storyboard
@@ -40,7 +40,7 @@
                                                     <color key="textColor" name="text1"/>
                                                     <nil key="highlightedColor"/>
                                                     <userDefinedRuntimeAttributes>
-                                                        <userDefinedRuntimeAttribute type="string" keyPath="xibLocalizedStringKey" value=" colorTheme"/>
+                                                        <userDefinedRuntimeAttribute type="string" keyPath="xibLocalizedStringKey" value="colorTheme"/>
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="None" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Jqq-Wr-d82">


### PR DESCRIPTION
closes #825
<img height="500" alt="Screenshot 2021-09-07 at 15 16 35" src="https://user-images.githubusercontent.com/794430/132360359-125f788f-2e87-4e20-8ee6-97fe12df2868.png">
