### PR TITLE
add info icon to explain transaction byte size

### DIFF
--- a/Decred Wallet/Features/Send/Send.storyboard
+++ b/Decred Wallet/Features/Send/Send.storyboard
@@ -541,6 +541,15 @@
                                                                                 <color key="textColor" name="text1"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
+                                                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sMA-aN-gjZ">
+                                                                                <rect key="frame" x="118" y="87" width="20" height="20"/>
+                                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                                                <state key="normal" image="ic_info"/>
+                                                                                <connections>
+                                                                                    <action selector="txByteSizeInfoButtonTapped:" destination="QI0-Sp-Mco" eventType="touchUpInside" id="7XF-tC-qi9"/>
+                                                                                </connections>
+                                                                            </button>
                                                                         </subviews>
                                                                         <color key="backgroundColor" name="background"/>
                                                                         <constraints>

--- a/Decred Wallet/Features/Send/SendViewController.swift
+++ b/Decred Wallet/Features/Send/SendViewController.swift
@@ -272,6 +272,14 @@ class SendViewController: UIViewController {
         present(alertController, animated: true, completion: nil)
     }
     
+    @IBAction func txByteSizeInfoButtonTapped(_ sender: Any) {
+        SimpleAlertDialog.show(sender: self,
+                               title: LocalizedStrings.transactionSize,
+                               attribMessage: LocalizedStrings.tx_size_info.htmlToAttributedString,
+                                  okButtonText: LocalizedStrings.gotIt,
+                                  callback: nil)
+    }
+    
     @IBAction func overflowMenuButtonTapped(_ sender: UIView) {
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         let cancelAction = UIAlertAction(title: LocalizedStrings.cancel, style: .cancel, handler: nil)

--- a/Decred Wallet/Utils/LocalizedStrings.swift
+++ b/Decred Wallet/Utils/LocalizedStrings.swift
@@ -257,6 +257,7 @@ struct LocalizedStrings {
     static let destinationAddress = NSLocalizedString("destinationAddress", comment: "")
     static let toSelf = NSLocalizedString("toSelf", comment: "")
     static let transactionSent = NSLocalizedString("transactionSent", comment: "")
+    static let tx_size_info = NSLocalizedString("tx_size_info", comment: "")
     
     /* Recieve */
     static let copyOnTap = NSLocalizedString("copyOnTap", comment: "")

--- a/Decred Wallet/en.lproj/Localizable.strings
+++ b/Decred Wallet/en.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "toDestinationAddress" = "To destination address";
 "destinationAddress" = "Destination Address";
 "transactionSent" = "Transaction sent";
+"tx_size_info" = "<span style=\"font-family: 'SourceSansPro-Regular'; font-size: 16px; color: #3D5873\">Transaction size is determined by how many inputs and outputs are required to fulfill a transaction.<br/><br/>Typically, larger quantities transacted require larger transaction sizes, which in turn create larger transaction fees.</span>";
 
 /* Recieve */
 "walletAddrCopied" = "Address copied";

--- a/Decred Wallet/es.lproj/Localizable.strings
+++ b/Decred Wallet/es.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "toDestinationAddress" = "To destination address";
 "destinationAddress" = "Destination Address";
 "transactionSent" = "Transaction sent";
+"tx_size_info" = "<span style=\"font-family: 'SourceSansPro-Regular'; font-size: 16px; color: #3D5873\">Transaction size is determined by how many inputs and outputs are required to fulfill a transaction.<br/><br/>Typically, larger quantities transacted require larger transaction sizes, which in turn create larger transaction fees.</span>";
 
 /* Recieve */
 "walletAddrCopied" = "Dirección copiada al portapapeles.";

--- a/Decred Wallet/fr.lproj/Localizable.strings
+++ b/Decred Wallet/fr.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "toDestinationAddress" = "Vers adresse de destination";
 "destinationAddress" = "Adresse de destination";
 "transactionSent" = "Transaction envoyée";
+"tx_size_info" = "<span style=\"font-family: 'SourceSansPro-Regular'; font-size: 16px; color: #3D5873\">Transaction size is determined by how many inputs and outputs are required to fulfill a transaction.<br/><br/>Typically, larger quantities transacted require larger transaction sizes, which in turn create larger transaction fees.</span>";
 
 /* Recieve */
 "walletAddrCopied" = "Adresse copiée";

--- a/Decred Wallet/pl.lproj/Localizable.strings
+++ b/Decred Wallet/pl.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "toDestinationAddress" = "Na adres docelowy";
 "destinationAddress" = "Destination Address";
 "transactionSent" = "Transaction sent";
+"tx_size_info" = "<span style=\"font-family: 'SourceSansPro-Regular'; font-size: 16px; color: #3D5873\">Transaction size is determined by how many inputs and outputs are required to fulfill a transaction.<br/><br/>Typically, larger quantities transacted require larger transaction sizes, which in turn create larger transaction fees.</span>";
 
 /* Recieve */
 "walletAddrCopied" = "Skopiowano adres do schowka";

--- a/Decred Wallet/pt-BR.lproj/Localizable.strings
+++ b/Decred Wallet/pt-BR.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "toDestinationAddress" = "To destination address";
 "destinationAddress" = "Destination Address";
 "transactionSent" = "Transaction sent";
+"tx_size_info" = "<span style=\"font-family: 'SourceSansPro-Regular'; font-size: 16px; color: #3D5873\">Transaction size is determined by how many inputs and outputs are required to fulfill a transaction.<br/><br/>Typically, larger quantities transacted require larger transaction sizes, which in turn create larger transaction fees.</span>";
 
 /* Recieve */
 "walletAddrCopied" = "Endereço copiado para área de transferência.";

--- a/Decred Wallet/ru-RU.lproj/Localizable.strings
+++ b/Decred Wallet/ru-RU.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "toDestinationAddress" = "To destination address";
 "destinationAddress" = "Destination Address";
 "transactionSent" = "Transaction sent";
+"tx_size_info" = "<span style=\"font-family: 'SourceSansPro-Regular'; font-size: 16px; color: #3D5873\">Transaction size is determined by how many inputs and outputs are required to fulfill a transaction.<br/><br/>Typically, larger quantities transacted require larger transaction sizes, which in turn create larger transaction fees.</span>";
 
 /* Recieve */
 "walletAddrCopied" = "Адрес скопирован в буфер обмена.";

--- a/Decred Wallet/vi.lproj/Localizable.strings
+++ b/Decred Wallet/vi.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "toDestinationAddress" = "Đến địa chỉ đích";
 "destinationAddress" = "Địa chỉ đích";
 "transactionSent" = "Giao dịch đã được gửi";
+"tx_size_info" = "<span style=\"font-family: 'SourceSansPro-Regular'; font-size: 16px; color: #3D5873\">Transaction size is determined by how many inputs and outputs are required to fulfill a transaction.<br/><br/>Typically, larger quantities transacted require larger transaction sizes, which in turn create larger transaction fees.</span>";
 
 /* Recieve */
 "walletAddrCopied" = "Địa chỉ được sao chép vào clipboard.";

--- a/Decred Wallet/zh-Hans.lproj/Localizable.strings
+++ b/Decred Wallet/zh-Hans.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "toDestinationAddress" = "发送地址";
 "destinationAddress" = "目标地址";
 "transactionSent" = "发送交易";
+"tx_size_info" = "<span style=\"font-family: 'SourceSansPro-Regular'; font-size: 16px; color: #3D5873\">Transaction size is determined by how many inputs and outputs are required to fulfill a transaction.<br/><br/>Typically, larger quantities transacted require larger transaction sizes, which in turn create larger transaction fees.</span>";
 
 /* Recieve */
 "walletAddrCopied" = "地址已复制到剪贴板.";


### PR DESCRIPTION
Resolves #868

This PR adds an info icon that explains how the transaction byte size is determined

**Screenshots**

| <img src="https://user-images.githubusercontent.com/25265396/143436709-d25385bf-e130-41b1-999c-f058e17eb5bc.png" height="500">|<img src="https://user-images.githubusercontent.com/25265396/143436737-7d949b61-a8bc-48bb-87bb-575e9e13c677.png" height="500"> |
|-|-|


