### PR TITLE
notify user when available disk space is low

### DIFF
--- a/Decred Wallet/BuildConfig.swift
+++ b/Decred Wallet/BuildConfig.swift
@@ -15,10 +15,14 @@ struct BuildConfig {
     static let TicketMaturity = 16
     static let NetType = "testnet3"
     static let PoliteiaHost = DcrlibwalletPoliteiaTestnetHost
+    static let GenesisTimestamp = 1533513600
+    static let TargetTimePerBlock = 120
     #else
     static let IsTestNet = false
     static let TicketMaturity = 256
     static let NetType = "mainnet"
     static let PoliteiaHost = DcrlibwalletPoliteiaMainnetHost
+    static let GenesisTimestamp = 1454954400
+    static let TargetTimePerBlock = 300
     #endif
 }

--- a/Decred Wallet/Extensions/UIViewController.swift
+++ b/Decred Wallet/Extensions/UIViewController.swift
@@ -159,6 +159,31 @@ extension UIViewController {
             )
         })
     }
+    
+    func deviceRemainingFreeSpaceInBytes () -> Int64? {
+        let documentDirectory = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).last!
+            guard
+                let systemAttributes = try? FileManager.default.attributesOfFileSystem(forPath: documentDirectory),
+                let freeSize = systemAttributes[.systemFreeSize] as? NSNumber
+            else {
+                return nil
+            }
+            return freeSize.int64Value
+    }
+    
+    func checkStorageSpace() {
+        if let storage = self.deviceRemainingFreeSpaceInBytes() {
+            let currentTime = Date().timeIntervalSince1970
+            let estimatedBlocksSinceGenesis = (Int(currentTime) - BuildConfig.GenesisTimestamp) / BuildConfig.TargetTimePerBlock
+            let estimatedHeadersSize = estimatedBlocksSinceGenesis/1000
+            if estimatedHeadersSize > storage {
+                //warning low storage for user
+                let alertController = UIAlertController(title: LocalizedStrings.lowStorageSpace, message: String(format: LocalizedStrings.lowStorageMessage, estimatedHeadersSize, storage), preferredStyle: UIAlertController.Style.alert)
+                alertController.addAction(UIAlertAction(title: LocalizedStrings.gotIt, style: UIAlertAction.Style.default, handler: nil))
+                self.present(alertController, animated: true, completion: nil)
+            }
+        }
+    }
 }
 
 // DirectTapGestureRecognizer disregards touch events not recieved directly from the `target` view.

--- a/Decred Wallet/Features/App Launch/StartScreenViewController.swift
+++ b/Decred Wallet/Features/App Launch/StartScreenViewController.swift
@@ -244,6 +244,7 @@ class StartScreenViewController: UIViewController, CAAnimationDelegate {
         } else {
             self.displayWalletSetupScreen()
             self.imageViewContainer.isUserInteractionEnabled = false
+            self.checkStorageSpace()
         }
     }
     

--- a/Decred Wallet/Features/Overview/OverviewViewController.swift
+++ b/Decred Wallet/Features/Overview/OverviewViewController.swift
@@ -147,7 +147,7 @@ class OverviewViewController: UIViewController {
         } else {
             self.usdBalanceLabelHeight.constant = 0
         }
-        
+        self.checkStorageSpace()
     }
     
     override func viewWillDisappear(_ animated: Bool) {

--- a/Decred Wallet/Utils/LocalizedStrings.swift
+++ b/Decred Wallet/Utils/LocalizedStrings.swift
@@ -455,6 +455,9 @@ struct LocalizedStrings {
     static let allowOnce = NSLocalizedString("allowOnce", comment: "")
     static let alwaysAllow = NSLocalizedString("alwaysAllow", comment: "")
     static let notNow = NSLocalizedString("notNow", comment: "")
+    static let lowStorageSpace = NSLocalizedString("lowStorageSpace", comment: "")
+    static let lowStorageMessage = NSLocalizedString("lowStorageMessage", comment: "")
+    static let exitCap = NSLocalizedString("exitCap", comment: "")
 
     /* Other text */
     static let security = NSLocalizedString("security", comment: "")

--- a/Decred Wallet/en.lproj/Localizable.strings
+++ b/Decred Wallet/en.lproj/Localizable.strings
@@ -492,6 +492,8 @@
 "allowOnce" = "Allow once";
 "alwaysAllow" = "Always allow";
 "notNow" = "Not now";
+"lowStorageSpace" = "Low Storage Space";
+"lowStorageMessage" = "Your device storage space is low and is not enough to sync a wallet. Required space to sync a wallet is ~%dmb while your free internal memory is %lldmb";
 
 /* Other Text */
 "send" = "send";

--- a/Decred Wallet/es.lproj/Localizable.strings
+++ b/Decred Wallet/es.lproj/Localizable.strings
@@ -394,6 +394,8 @@
 "politeiaVersion" = "version %@";
 "noPoliteia" = "Sin propuesta";
 "syncPoliteiaTryAgain" = "There was an error when sync politeia, please try again in Politeia";
+"lowStorageSpace" = "Low Storage Space";
+"lowStorageMessage" = "Your device storage space is low and is not enough to sync a wallet. Required space to sync a wallet is ~%dmb while your free internal memory is %lldmb";
 
 /* Settings */
 "startupPinPass" = "PIN/Contraseña de inicio";

--- a/Decred Wallet/fr.lproj/Localizable.strings
+++ b/Decred Wallet/fr.lproj/Localizable.strings
@@ -492,6 +492,8 @@
 "allowOnce" = "Allow once";
 "alwaysAllow" = "Always allow";
 "notNow" = "Pas maintenant";
+"lowStorageSpace" = "Low Storage Space";
+"lowStorageMessage" = "Your device storage space is low and is not enough to sync a wallet. Required space to sync a wallet is ~%dmb while your free internal memory is %lldmb";
 
 /* Other Text */
 "send" = "envoyer";

--- a/Decred Wallet/pl.lproj/Localizable.strings
+++ b/Decred Wallet/pl.lproj/Localizable.strings
@@ -492,6 +492,8 @@
 "allowOnce" = "Allow once";
 "alwaysAllow" = "Always allow";
 "notNow" = "Nie teraz";
+"lowStorageSpace" = "Low Storage Space";
+"lowStorageMessage" = "Your device storage space is low and is not enough to sync a wallet. Required space to sync a wallet is ~%dmb while your free internal memory is %lldmb";
 
 /* Other Text */
 "send" = "Wyślij";

--- a/Decred Wallet/pt-BR.lproj/Localizable.strings
+++ b/Decred Wallet/pt-BR.lproj/Localizable.strings
@@ -492,6 +492,8 @@
 "allowOnce" = "Allow once";
 "alwaysAllow" = "Always allow";
 "notNow" = "Not now";
+"lowStorageSpace" = "Low Storage Space";
+"lowStorageMessage" = "Your device storage space is low and is not enough to sync a wallet. Required space to sync a wallet is ~%dmb while your free internal memory is %lldmb";
 
 /* Other Text */
 "send" = "send";

--- a/Decred Wallet/ru-RU.lproj/Localizable.strings
+++ b/Decred Wallet/ru-RU.lproj/Localizable.strings
@@ -492,6 +492,8 @@
 "allowOnce" = "Allow once";
 "alwaysAllow" = "Always allow";
 "notNow" = "Not now";
+"lowStorageSpace" = "Low Storage Space";
+"lowStorageMessage" = "Your device storage space is low and is not enough to sync a wallet. Required space to sync a wallet is ~%dmb while your free internal memory is %lldmb";
 
 /* Other Text */
 "send" = "send";

--- a/Decred Wallet/vi.lproj/Localizable.strings
+++ b/Decred Wallet/vi.lproj/Localizable.strings
@@ -492,6 +492,8 @@
 "allowOnce" = "Cho phép 1 lần";
 "alwaysAllow" = "Luôn cho phép";
 "notNow" = "Không phải bây giờ";
+"lowStorageSpace" = "Low Storage Space";
+"lowStorageMessage" = "Your device storage space is low and is not enough to sync a wallet. Required space to sync a wallet is ~%dmb while your free internal memory is %lldmb";
 
 /* Other Text */
 "send" = "gửi";

--- a/Decred Wallet/zh-Hans.lproj/Localizable.strings
+++ b/Decred Wallet/zh-Hans.lproj/Localizable.strings
@@ -492,6 +492,8 @@
 "allowOnce" = "允许一次";
 "alwaysAllow" = "总是允许";
 "notNow" = "现在不";
+"lowStorageSpace" = "Low Storage Space";
+"lowStorageMessage" = "Your device storage space is low and is not enough to sync a wallet. Required space to sync a wallet is ~%dmb while your free internal memory is %lldmb";
 
 /* Other Text */
 "send" = "发送";


### PR DESCRIPTION
This PR resolve #867 and #458 
Notify user when disk space is low in start page and home page
Popup don't show exit button like dcrandroid because it is not recommended by Apple and won't be accepted by the AppStore.

|<img src="https://user-images.githubusercontent.com/19331824/145926702-3bf37e8b-b625-450e-a478-aa22598b4ec2.png" height="500" style="max-width: 100%;">|<img src="https://user-images.githubusercontent.com/19331824/145926715-1c3d0dc6-0e33-4279-9dd8-593e40e059b1.png" height="500" style="max-width: 100%;">|
|-|-|
