### PR TITLE
fix bug where QR code wasn't scannable from dcrandroid

### DIFF
--- a/Decred Wallet/Features/Receive/Receive.storyboard
+++ b/Decred Wallet/Features/Receive/Receive.storyboard
@@ -102,6 +102,10 @@
                                                                     <constraint firstAttribute="width" secondItem="P2Q-l4-CRY" secondAttribute="height" id="joC-Jr-vOs"/>
                                                                 </constraints>
                                                             </imageView>
+                                                            <imageView hidden="YES" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="ic_qr_logo" translatesAutoresizingMaskIntoConstraints="NO" id="tOY-mw-rzl">
+                                                                <rect key="frame" x="174" y="142" width="50" height="50"/>
+                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                            </imageView>
                                                         </subviews>
                                                         <color key="backgroundColor" name="surface"/>
                                                         <constraints>
@@ -242,6 +246,7 @@
                         <outlet property="addressQRCodeContainerView" destination="cCf-CG-EBq" id="hVt-n3-8Rr"/>
                         <outlet property="addressQRCodeImageView" destination="P2Q-l4-CRY" id="2cl-JZ-uxS"/>
                         <outlet property="moreMenuButton" destination="fEY-wz-2Xy" id="Gg6-Pn-VHS"/>
+                        <outlet property="qrCodeLogoImageView" destination="tOY-mw-rzl" id="mmr-vH-Xt8"/>
                         <outlet property="selectedAccountView" destination="GdJ-3u-Cn7" id="Ain-vS-iWx"/>
                         <outlet property="separatorView" destination="ELj-zD-ScR" id="yc8-aw-UQU"/>
                         <outlet property="shareButtonContainerView" destination="Bxh-8Q-KbY" id="OTv-sD-l8Y"/>
@@ -263,6 +268,7 @@
         <image name="ic_close" width="24" height="24"/>
         <image name="ic_info" width="24" height="24"/>
         <image name="ic_more" width="24" height="24"/>
+        <image name="ic_qr_logo" width="47" height="47"/>
         <image name="ic_share" width="24" height="24"/>
         <namedColor name="background">
             <color red="0.95294117647058818" green="0.96078431372549022" blue="0.96470588235294119" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Decred Wallet/Features/Receive/ReceiveViewController.swift
+++ b/Decred Wallet/Features/Receive/ReceiveViewController.swift
@@ -15,6 +15,7 @@ class ReceiveViewController: UIViewController {
     @IBOutlet weak var separatorView: UIView!
     @IBOutlet weak var addressQRCodeContainerView: UIView!
     @IBOutlet weak var addressQRCodeImageView: UIImageView!
+    @IBOutlet weak var qrCodeLogoImageView: UIImageView!
     @IBOutlet weak var walletAddressLabel: UILabel!
     @IBOutlet weak var tapToCopyContainerView: UIView!
     @IBOutlet weak var shareButtonContainerView: UIView!
@@ -82,14 +83,18 @@ class ReceiveViewController: UIViewController {
             return
         }
         
-        let swiftLeeBlackColor = UIColor.white
-        let swiftLeeLogo = UIImage(named: "ic_qr_logo")!
+        let data = address.data(using: String.Encoding.ascii)
+         if let filter = CIFilter(name: "CIQRCodeGenerator") {
+             filter.setValue(data, forKey: "inputMessage")
+             let transform = CGAffineTransform(scaleX: 3, y: 3)
 
-        if let qrURLImage = URL(string: address)?.qrImage(using: swiftLeeBlackColor, logo: swiftLeeLogo, frame: self.addressQRCodeImageView.frame) {
-            self.addressQRCodeImageView.image = UIImage(ciImage: qrURLImage)
-        } else {
-            self.addressQRCodeImageView.image = nil
-        }
+             if let output = filter.outputImage?.transformed(by: transform) {
+                self.qrCodeLogoImageView.isHidden = false
+                self.addressQRCodeImageView.image = UIImage(ciImage: output)
+             } else {
+                self.addressQRCodeImageView.image = nil
+             }
+         }
     }
 
     @IBAction func onClose(_ sender: Any) {


### PR DESCRIPTION
Closes  https://github.com/planetdecred/dcrandroid/issues/609

This PR fixes a bug where the QRCode for the receive address wasn't scannable from dcrandroid, the issue was found to be with the code logic that displays the QRCode, as when the logo was removed the QRCode wasn't still scannable from dcrandroid.

The fix implemented in this PR was to add the qr image logo in the UI Storyboard, instead of adding the logo programatically. And to also implement a new logic to display the QRCode