### PR TITLE
Reworked sent DCR page

### DIFF
--- a/Decred Wallet/Assets.xcassets/success_checked.imageset/Contents.json
+++ b/Decred Wallet/Assets.xcassets/success_checked.imageset/Contents.json
@@ -1,23 +1,26 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
       "filename" : "ic_checkmark02_24px.png",
+      "idiom" : "universal",
       "scale" : "1x"
     },
     {
-      "idiom" : "universal",
       "filename" : "ic_checkmark02_24px@2x.png",
+      "idiom" : "universal",
       "scale" : "2x"
     },
     {
-      "idiom" : "universal",
       "filename" : "ic_checkmark02_24px@3x.png",
+      "idiom" : "universal",
       "scale" : "3x"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/Decred Wallet/Features/Send/ConfirmToSendFundViewController.swift
+++ b/Decred Wallet/Features/Send/ConfirmToSendFundViewController.swift
@@ -30,6 +30,8 @@ class ConfirmToSendFundViewController: UIViewController, UITextFieldDelegate {
     @IBOutlet weak var balanceAfterSendLabel: UILabel!
     @IBOutlet weak var sendButton: Button!
     
+    @IBOutlet weak var infoLabel: UILabel!
+    @IBOutlet weak var titleLabel: UILabel!
     var sourceWalletID: Int!
     var unsignedTxSummary: UnsignedTxSummary!
     var unsignedTx: DcrlibwalletTxAuthor!
@@ -133,7 +135,7 @@ class ConfirmToSendFundViewController: UIViewController, UITextFieldDelegate {
                 if let passOrPin = result {
                     self.broadcastUnsignedTxInBackground(privatePass: passOrPin) { err in
                         if err == nil {
-                            self.dismissView()
+                            self.showSuccess()
                             self.onSendCompleted?()
                         }
                     }
@@ -146,6 +148,29 @@ class ConfirmToSendFundViewController: UIViewController, UITextFieldDelegate {
         }
     }
     
+    private func showSuccess() {
+        self.titleLabel.text = LocalizedStrings.transactionDetails
+        let mainTextColor = UIColor.appColors.text1
+        let subTextColor = UIColor.appColors.text2
+        let sourceAccountInfo = Utils.styleAttributedString(
+            String(format: "Sent from <bold>%@</bold>", self.unsignedTxSummary.sourceAccountInfo), // localize!
+            styles: [
+                AttributedStringStyle(tag: "bold", fontFamily: "SourceSansPro-SemiBold", fontSize: 14, color: mainTextColor)
+            ],
+            defaultStyle: AttributedStringStyle(fontFamily: "SourceSansPro-Regular", fontSize: 14, color: subTextColor)
+        )
+        self.sendingFromLabel.attributedText = sourceAccountInfo
+        
+        self.infoLabel.text = LocalizedStrings.sendWarningSuccess
+        
+        self.sendButton.setImage(UIImage(named: "success_checked"), for: .normal)
+        self.sendButton.setTitle(LocalizedStrings.success, for: .normal)
+        self.sendButton.titleEdgeInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0)
+        self.sendButton.setTitleColor(UIColor.appColors.green, for: .normal)
+        self.sendButton.isUserInteractionEnabled = false
+        self.sendButton.backgroundColor = UIColor.clear
+    }
+    
     private func sendUsingPassOrPin() {
         let privatePassType = SpendingPinOrPassword.securityType(for: self.sourceWalletID)
         Security.spending(initialSecurityType: privatePassType)
@@ -155,7 +180,7 @@ class ConfirmToSendFundViewController: UIViewController, UITextFieldDelegate {
                 self.broadcastUnsignedTxInBackground(privatePass: privatePass) { error in
                     if error == nil {
                         dialogDelegate?.dismissDialog()
-                        self.dismissView()
+                        self.showSuccess()
                         self.onSendCompleted?()
                     } else if error!.isInvalidPassphraseError {
                         let errorMessage = SpendingPinOrPassword.invalidSecurityCodeMessage(for: self.sourceWalletID)

--- a/Decred Wallet/Features/Send/Send.storyboard
+++ b/Decred Wallet/Features/Send/Send.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -90,7 +90,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="877.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="E7K-3J-yiV">
-                                                <rect key="frame" x="8" y="0.0" width="398" height="890"/>
+                                                <rect key="frame" x="8" y="0.0" width="398" height="892.5"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Se0-MS-xbk" customClass="RoundedView" customModule="Decred_Wallet" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="0.0" width="398" height="125"/>
@@ -141,7 +141,7 @@
                                                         </userDefinedRuntimeAttributes>
                                                     </view>
                                                     <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yZ1-l0-nEc" customClass="RoundedView" customModule="Decred_Wallet" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="133" width="398" height="154.5"/>
+                                                        <rect key="frame" x="0.0" y="133" width="398" height="157"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="To" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aua-j2-wqg">
                                                                 <rect key="frame" x="16" y="16" width="14.5" height="18"/>
@@ -166,10 +166,10 @@
                                                                 </connections>
                                                             </button>
                                                             <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="kma-kO-ySG">
-                                                                <rect key="frame" x="16" y="50" width="366" height="88.5"/>
+                                                                <rect key="frame" x="16" y="50" width="366" height="91"/>
                                                                 <subviews>
                                                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="JDR-oq-YJC" customClass="FloatingPlaceholderTextView" customModule="Decred_Wallet" customModuleProvider="target">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="366" height="73"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="366" height="75.5"/>
                                                                         <color key="backgroundColor" name="surface"/>
                                                                         <color key="textColor" systemColor="labelColor"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -180,7 +180,7 @@
                                                                         </userDefinedRuntimeAttributes>
                                                                     </textView>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Invalid address" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="19H-1W-F1v" customClass="Label" customModule="Decred_Wallet" customModuleProvider="target">
-                                                                        <rect key="frame" x="0.0" y="73" width="366" height="15.5"/>
+                                                                        <rect key="frame" x="0.0" y="75.5" width="366" height="15.5"/>
                                                                         <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="12"/>
                                                                         <color key="textColor" red="0.92941176469999998" green="0.42745098040000001" blue="0.2784313725" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                         <nil key="highlightedColor"/>
@@ -236,7 +236,7 @@
                                                         </userDefinedRuntimeAttributes>
                                                     </view>
                                                     <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Fie-VD-jFK" customClass="RoundedView" customModule="Decred_Wallet" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="295.5" width="398" height="140"/>
+                                                        <rect key="frame" x="0.0" y="298" width="398" height="140"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="To" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CZf-lR-xrW">
                                                                 <rect key="frame" x="16" y="22" width="14.5" height="18"/>
@@ -302,7 +302,7 @@
                                                         </userDefinedRuntimeAttributes>
                                                     </view>
                                                     <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yYA-6r-dFg" customClass="RoundedView" customModule="Decred_Wallet" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="443.5" width="398" height="446.5"/>
+                                                        <rect key="frame" x="0.0" y="446" width="398" height="446.5"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="q2W-cT-s6V">
                                                                 <rect key="frame" x="16" y="16" width="366" height="18"/>
@@ -1049,9 +1049,11 @@
                         <outlet property="balanceAfterSendLabel" destination="lPq-24-2mO" id="awH-8n-fH4"/>
                         <outlet property="destinationInfoLabel" destination="JLL-4K-S63" id="a1v-y8-OWd"/>
                         <outlet property="destinationTypeLabel" destination="0An-yk-jZi" id="LNe-Rb-hg0"/>
+                        <outlet property="infoLabel" destination="gav-BH-WCe" id="chv-ox-uct"/>
                         <outlet property="sendButton" destination="zuF-dd-eap" id="YMs-jH-ZIK"/>
                         <outlet property="sendingAmountLabel" destination="lxH-eS-8vg" id="fcR-1K-Z2n"/>
                         <outlet property="sendingFromLabel" destination="Ijc-AC-2ul" id="9Z8-1u-OOg"/>
+                        <outlet property="titleLabel" destination="xZE-vD-HWT" id="WNu-hP-SNm"/>
                         <outlet property="totalCostLabel" destination="GOq-up-oAS" id="UWQ-s7-qaH"/>
                         <outlet property="txFeeLabel" destination="KSo-oZ-Kra" id="0fX-it-9jj"/>
                     </connections>

--- a/Decred Wallet/Features/Send/SendViewController.swift
+++ b/Decred Wallet/Features/Send/SendViewController.swift
@@ -464,11 +464,7 @@ class SendViewController: UIViewController {
     }
     
     func sendCompleted() {
-        Utils.showBanner(in: NavigationMenuTabBarController.instance!.view, type: .success, text: LocalizedStrings.transactionSent)
         self.resetFields()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            self.dismissView()
-        }
     }
 }
 

--- a/Decred Wallet/Utils/LocalizedStrings.swift
+++ b/Decred Wallet/Utils/LocalizedStrings.swift
@@ -252,6 +252,7 @@ struct LocalizedStrings {
     static let totalCost = NSLocalizedString("totalCost", comment: "")
     static let balanceAfterSend = NSLocalizedString("balanceAfterSend", comment: "")
     static let sendWarning = NSLocalizedString("sendWarning", comment: "")
+    static let sendWarningSuccess = NSLocalizedString("sendWarningSuccess", comment: "")
     static let sendingAccount = NSLocalizedString("sendingAccount", comment: "")
     static let toDestinationAddress = NSLocalizedString("toDestinationAddress", comment: "")
     static let destinationAddress = NSLocalizedString("destinationAddress", comment: "")

--- a/Decred Wallet/en.lproj/Localizable.strings
+++ b/Decred Wallet/en.lproj/Localizable.strings
@@ -254,6 +254,7 @@
 "totalCost" = "Total Cost";
 "balanceAfterSend" = "Balance after send";
 "sendWarning" = "Your DCR will be sent and CANNOT be undone.";
+"sendWarningSuccess" = "Your DCR has been sent and CANNOT be undone.";
 "sendingAccount" = "Sending Account";
 "toSelf" = "To self";
 "toDestinationAddress" = "To destination address";

--- a/Decred Wallet/es.lproj/Localizable.strings
+++ b/Decred Wallet/es.lproj/Localizable.strings
@@ -254,6 +254,7 @@
 "totalCost" = "Total Cost";
 "balanceAfterSend" = "Balance after send";
 "sendWarning" = "Your DCR will be sent and CANNOT be undone.";
+"sendWarningSuccess" = "Your DCR has been sent and CANNOT be undone.";
 "sendingAccount" = "Sending Account";
 "toSelf" = "To self";
 "toDestinationAddress" = "To destination address";

--- a/Decred Wallet/fr.lproj/Localizable.strings
+++ b/Decred Wallet/fr.lproj/Localizable.strings
@@ -254,6 +254,7 @@
 "totalCost" = "Total Cost";
 "balanceAfterSend" = "Solde après envoi";
 "sendWarning" = "Vos DCR seront envoyés et cela NE PEUT PAS être annulé.";
+"sendWarningSuccess" = "Your DCR has been sent and CANNOT be undone.";
 "sendingAccount" = "Envoi du compte";
 "toSelf" = "Vers soi-même";
 "toDestinationAddress" = "Vers adresse de destination";

--- a/Decred Wallet/pl.lproj/Localizable.strings
+++ b/Decred Wallet/pl.lproj/Localizable.strings
@@ -254,6 +254,7 @@
 "totalCost" = "Całkowity koszt";
 "balanceAfterSend" = "Saldo po transakcji";
 "sendWarning" = "Twoje DCR zostaną wysłane; tej operacji NIE DA SIĘ cofnąć.";
+"sendWarningSuccess" = "Your DCR has been sent and CANNOT be undone.";
 "sendingAccount" = "Konto wysyłające";
 "toSelf" = "Do siebie";
 "toDestinationAddress" = "Na adres docelowy";

--- a/Decred Wallet/pt-BR.lproj/Localizable.strings
+++ b/Decred Wallet/pt-BR.lproj/Localizable.strings
@@ -254,6 +254,7 @@
 "totalCost" = "Total Cost";
 "balanceAfterSend" = "Balance after send";
 "sendWarning" = "Your DCR will be sent and CANNOT be undone.";
+"sendWarningSuccess" = "Your DCR has been sent and CANNOT be undone.";
 "sendingAccount" = "Sending Account";
 "toSelf" = "To self";
 "toDestinationAddress" = "To destination address";

--- a/Decred Wallet/ru-RU.lproj/Localizable.strings
+++ b/Decred Wallet/ru-RU.lproj/Localizable.strings
@@ -254,6 +254,7 @@
 "totalCost" = "Total Cost";
 "balanceAfterSend" = "Balance after send";
 "sendWarning" = "Your DCR will be sent and CANNOT be undone.";
+"sendWarningSuccess" = "Your DCR has been sent and CANNOT be undone.";
 "sendingAccount" = "Sending Account";
 "toSelf" = "To self";
 "toDestinationAddress" = "To destination address";

--- a/Decred Wallet/vi.lproj/Localizable.strings
+++ b/Decred Wallet/vi.lproj/Localizable.strings
@@ -254,6 +254,7 @@
 "totalCost" = "Tổng chi phí";
 "balanceAfterSend" = "Số dư sau khi gửi";
 "sendWarning" = "DCR của bạn sẽ được gửi và KHÔNG THỂ hoàn tác.";
+"sendWarningSuccess" = "DCR của bạn đã được gửi và KHÔNG THỂ hoàn tác.";
 "sendingAccount" = "Tài khoản gửi";
 "toSelf" = "Gửi cho bản thân";
 "toDestinationAddress" = "Đến địa chỉ đích";

--- a/Decred Wallet/zh-Hans.lproj/Localizable.strings
+++ b/Decred Wallet/zh-Hans.lproj/Localizable.strings
@@ -254,6 +254,7 @@
 "totalCost" = "总成本";
 "balanceAfterSend" = "发送后余额";
 "sendWarning" = "点击发送后将无法撤销";
+"sendWarningSuccess" = "Your DCR has been sent and CANNOT be undone.";
 "sendingAccount" = "发送账户";
 "toSelf" = "对自己";
 "toDestinationAddress" = "发送地址";


### PR DESCRIPTION
Resolve #894 

This PR reworks the success dialog providing users more context to the successful transaction.

**Screenshot**

<img src="https://user-images.githubusercontent.com/19331824/165366401-4480ec34-df0c-49dc-bbe1-aca055b51ec2.png" height="500">

