### PR TITLE
identify already existing wallets before adding a new wallet

### DIFF
--- a/Decred Wallet/Features/Wallet Setup/RestoreExistingWalletViewController.swift
+++ b/Decred Wallet/Features/Wallet Setup/RestoreExistingWalletViewController.swift
@@ -101,6 +101,23 @@ class RestoreExistingWalletViewController: UIViewController {
             Utils.showBanner(in: self.view, type: .error, text: LocalizedStrings.incorrectSeedEntered)
             return
         }
+        
+        // Compare seed with existing wallet seed
+        var walletID = 1
+        let op = "wallet.restoreWallet error:"
+        do {
+            try WalletLoader.shared.multiWallet.wallet(withSeed: seed, ret0_: &walletID)
+            if walletID != -1 {
+                Utils.showBanner(in: self.view, type: .error, text: LocalizedStrings.wallet_with_seed_exist)
+                return
+            }
+        } catch let error {
+            DispatchQueue.main.async {
+                print(op, error.localizedDescription)
+                DcrlibwalletLogT(op, error.localizedDescription)
+                Utils.showBanner(in: self.view, type: .error, text: error.localizedDescription)
+            }
+        }
 
         self.tableView.isUserInteractionEnabled = false
         self.btnConfirm.setTitle(LocalizedStrings.success, for: .normal)

--- a/Decred Wallet/Features/Wallets/WalletsViewController.swift
+++ b/Decred Wallet/Features/Wallets/WalletsViewController.swift
@@ -233,6 +233,7 @@ class WalletsViewController: UIViewController {
                 try WalletLoader.shared.multiWallet.wallet(withXPub: walletPubKey, ret0_: &walletID)
                 if walletID != -1 {
                     Utils.showBanner(in: self.view, type: .error, text: LocalizedStrings.wallet_with_xpub_exist)
+                    dialogDelegate?.displayError(errorMessage: LocalizedStrings.wallet_with_xpub_exist, firstTextField: false)
                     return
                 }
             } catch let error {

--- a/Decred Wallet/Features/Wallets/WalletsViewController.swift
+++ b/Decred Wallet/Features/Wallets/WalletsViewController.swift
@@ -225,6 +225,24 @@ class WalletsViewController: UIViewController {
         userNamePlaceholder: LocalizedStrings.walletName,
         userPassPlaceholder: LocalizedStrings.extendedPublicKey,
         submitButtonText: LocalizedStrings.import_) { walletName, walletPubKey, dialogDelegate in
+            
+            // Compare xpub with existing wallet xpub
+            var walletID = 1
+            let op = "wallet.createWatchOnlyWallet error:"
+            do {
+                try WalletLoader.shared.multiWallet.wallet(withXPub: walletPubKey, ret0_: &walletID)
+                if walletID != -1 {
+                    Utils.showBanner(in: self.view, type: .error, text: LocalizedStrings.wallet_with_xpub_exist)
+                    return
+                }
+            } catch let error {
+                DispatchQueue.main.async {
+                    print(op, error.localizedDescription)
+                    DcrlibwalletLogT(op, error.localizedDescription)
+                    Utils.showBanner(in: self.view, type: .error, text: error.localizedDescription)
+                }
+            }
+            
             var errorValue: ObjCBool = false
             DispatchQueue.global(qos: .userInitiated).async {
                 do {

--- a/Decred Wallet/Utils/LocalizedStrings.swift
+++ b/Decred Wallet/Utils/LocalizedStrings.swift
@@ -46,6 +46,7 @@ struct LocalizedStrings {
     static let watchWalletImported = NSLocalizedString("watchWalletImported", comment: "")
     static let extendPublicKeyInfo = NSLocalizedString("extendPublicKeyInfo", comment: "")
     static let watchWalletTitle = NSLocalizedString("watchWalletTitle", comment: "")
+    static let wallet_with_xpub_exist = NSLocalizedString("wallet_with_xpub_exist", comment: "")
     
     /* Unlock Wallet Prompt */
     static let unlockWithStartupCode = NSLocalizedString("unlockWithStartupCode", comment: "")
@@ -281,6 +282,7 @@ struct LocalizedStrings {
     static let walletNameExists = NSLocalizedString("walletNameExists", comment: "")
     static let walletNameReserved = NSLocalizedString("walletNameReserved", comment: "")
     static let disconnectAddWallet = NSLocalizedString("disconnectAddWallet", comment: "")
+    static let wallet_with_seed_exist = NSLocalizedString("wallet_with_seed_exist", comment: "")
     
     /* Wallets -> Sign message */
     static let signMessage = NSLocalizedString("signMessage", comment: "")

--- a/Decred Wallet/en.lproj/Localizable.strings
+++ b/Decred Wallet/en.lproj/Localizable.strings
@@ -289,6 +289,9 @@
 "import_" = "Import";
 "keyIsInvalid" = "Key is invalid";
 "disconnectAddWallet" = "Disconnect/cancel sync before adding a wallet";
+"wallet_with_seed_exist" = "A wallet with an identical seed already exists.";
+"wallet_with_xpub_exist" = "A wallet with an identical extended public key already exists.";
+
 
 /* Wallets -> Sign message */
 "signMessage" = "Sign message";

--- a/Decred Wallet/es.lproj/Localizable.strings
+++ b/Decred Wallet/es.lproj/Localizable.strings
@@ -289,6 +289,8 @@
 "import_" = "Import";
 "keyIsInvalid" = "Key is invalid";
 "disconnectAddWallet" = "Disconnect/cancel sync before adding a wallet";
+"wallet_with_seed_exist" = "A wallet with an identical seed already exists.";
+"wallet_with_xpub_exist" = "A wallet with an identical extended public key already exists.";
 
 /* Wallets -> Sign message */
 "signMessage" = "Firmar Mensaje";

--- a/Decred Wallet/fr.lproj/Localizable.strings
+++ b/Decred Wallet/fr.lproj/Localizable.strings
@@ -289,6 +289,8 @@
 "import_" = "Importer";
 "keyIsInvalid" = "La clé est invalide";
 "disconnectAddWallet" = "Déconnecter/annuler la synchronisation avant d\'ajouter un porte-monnaie";
+"wallet_with_seed_exist" = "A wallet with an identical seed already exists.";
+"wallet_with_xpub_exist" = "A wallet with an identical extended public key already exists.";
 
 /* Wallets -> Sign message */
 "signMessage" = "Signer le message";

--- a/Decred Wallet/pl.lproj/Localizable.strings
+++ b/Decred Wallet/pl.lproj/Localizable.strings
@@ -289,6 +289,8 @@
 "import_" = "Import";
 "keyIsInvalid" = "Key is invalid";
 "disconnectAddWallet" = "Disconnect/cancel sync before adding a wallet";
+"wallet_with_seed_exist" = "A wallet with an identical seed already exists.";
+"wallet_with_xpub_exist" = "A wallet with an identical extended public key already exists.";
 
 /* Wallets -> Sign message */
 "signMessage" = "Podpisz wiadomość";

--- a/Decred Wallet/pt-BR.lproj/Localizable.strings
+++ b/Decred Wallet/pt-BR.lproj/Localizable.strings
@@ -289,6 +289,8 @@
 "import_" = "Import";
 "keyIsInvalid" = "Key is invalid";
 "disconnectAddWallet" = "Disconnect/cancel sync before adding a wallet";
+"wallet_with_seed_exist" = "A wallet with an identical seed already exists.";
+"wallet_with_xpub_exist" = "A wallet with an identical extended public key already exists.";
 
 /* Wallets -> Sign message */
 "signMessage" = "Assinar Mensagem";

--- a/Decred Wallet/ru-RU.lproj/Localizable.strings
+++ b/Decred Wallet/ru-RU.lproj/Localizable.strings
@@ -289,6 +289,8 @@
 "import_" = "Import";
 "keyIsInvalid" = "Key is invalid";
 "disconnectAddWallet" = "Disconnect/cancel sync before adding a wallet";
+"wallet_with_seed_exist" = "A wallet with an identical seed already exists.";
+"wallet_with_xpub_exist" = "A wallet with an identical extended public key already exists.";
 
 /* Wallets -> Sign message */
 "signMessage" = "Подписать сообщение";

--- a/Decred Wallet/vi.lproj/Localizable.strings
+++ b/Decred Wallet/vi.lproj/Localizable.strings
@@ -289,6 +289,8 @@
 "import_" = "Nhập vào";
 "keyIsInvalid" = "Key không hợp lệ";
 "disconnectAddWallet" = "Ngắt kết nối / hủy đồng bộ hóa trước khi thêm ví";
+"wallet_with_seed_exist" = "A wallet with an identical seed already exists.";
+"wallet_with_xpub_exist" = "A wallet with an identical extended public key already exists.";
 
 /* Wallets -> Sign message */
 "signMessage" = "Ký tin nhắn";

--- a/Decred Wallet/zh-Hans.lproj/Localizable.strings
+++ b/Decred Wallet/zh-Hans.lproj/Localizable.strings
@@ -289,6 +289,8 @@
 "import_" = "导入";
 "keyIsInvalid" = "密钥无效";
 "disconnectAddWallet" = "添加钱包之前断开/取消同步";
+"wallet_with_seed_exist" = "A wallet with an identical seed already exists.";
+"wallet_with_xpub_exist" = "A wallet with an identical extended public key already exists.";
 
 /* Wallets -> Sign message */
 "signMessage" = "签署消息";


### PR DESCRIPTION
Resolves #904 

The wallet prevents a user from adding a wallet that already exists, by comparing the wallet seed or the extended public key of the new wallet about to be added, against those of existing wallets.

The capability was introduced here https://github.com/planetdecred/dcrlibwallet/pull/244

**Screenshots**
|<img src="https://user-images.githubusercontent.com/25265396/165637896-bc88e2fb-bd84-4912-a252-91910b8ed7be.png" width="300" />|<img src="https://user-images.githubusercontent.com/25265396/165817957-939ce351-81b0-4692-95fd-afed99757008.png" width="300" /> |
|-|-|