### PR TITLE
Privacy: Skip "Setup needed accounts" page if the wallet has just one account

### DIFF
--- a/Decred Wallet/Extensions/Dcrlibwallet.swift
+++ b/Decred Wallet/Extensions/Dcrlibwallet.swift
@@ -181,6 +181,22 @@ extension DcrlibwalletWallet {
         
         return transactions
     }
+    
+    func hasAccountsImported() -> Bool {
+        let names: [String] = accounts.map {
+            return $0.name
+        }
+        
+        return names.contains("imported")
+    }
+    
+    func getAccountsRaw() -> Int {
+        do {
+            return try getAccountsRaw().count
+        } catch {
+            return 0
+        }
+    }
 }
 
 extension DcrlibwalletPoliteia {

--- a/Decred Wallet/Features/Privacy/PrivacySetupViewController.swift
+++ b/Decred Wallet/Features/Privacy/PrivacySetupViewController.swift
@@ -29,8 +29,102 @@ class PrivacySetupViewController: UIViewController {
             return
         }
         
-        let PrivacySetupTypeVC = PrivacySetupTypeViewController.instantiate(from: .Privacy)
-        PrivacySetupTypeVC.wallet = wallet
-        self.navigationController?.pushViewController(PrivacySetupTypeVC, animated: true)
+        if wallet.hasAccountsImported() {
+            if wallet.getAccountsRaw() - 1 > 2 {
+                let PrivacySetupTypeVC = PrivacySetupTypeViewController.instantiate(from: .Privacy)
+                PrivacySetupTypeVC.wallet = wallet
+                self.navigationController?.pushViewController(PrivacySetupTypeVC, animated: true)
+            } else {
+                self.checkAccountNameConflict()
+            }
+        }
+    }
+    
+    func showReminder(callback: @escaping (Bool) -> Void) {
+        let message = LocalizedStrings.setupMixerInfo
+        SimpleOkCancelDialog.show(sender: self,
+                                  title: LocalizedStrings.setupMixerWithTwoAccounts,
+                                  message: message,
+                                  warningText: LocalizedStrings.setupMixerWithTwoAccounts,
+                                  okButtonText: LocalizedStrings.beginSetup,
+                                  callback: callback)
+    }
+    
+    private func checkAccountNameConflict() {
+        if wallet.hasAccount(GlobalConstants.Strings.MIXED) || wallet.hasAccount(GlobalConstants.Strings.UNMIXED) {
+            SimpleAlertDialog.show(sender: self, title: LocalizedStrings.accountNameTaken, message: LocalizedStrings.accountNameTakenMsg, okButtonText: LocalizedStrings.goBackAndRename, hideAlertIcon: false) { ok in
+                self.navigationController?.popToRootViewController(animated: true)
+            }
+            return
+        }
+        self.AuthMixerAccount()
+    }
+    
+    func AuthMixerAccount() {
+        self.showReminder { ok in
+            guard ok else { return }
+            if LocalAuthentication.isWalletSetupBiometric(walletId: self.wallet.id_) {
+                LocalAuthentication.localAuthenticaionWithWallet(walletId: self.wallet.id_, completed: { result, error in
+                    if let passOrPin = result {
+                        DispatchQueue.global(qos: .userInitiated).async {
+                            do {
+                                try self.wallet.createMixerAccounts(GlobalConstants.Strings.MIXED, unmixedAccount: GlobalConstants.Strings.UNMIXED, privPass: passOrPin)
+                                WalletLoader.shared.multiWallet.setBoolConfigValueForKey("has_setup_privacy", value: true)
+                                
+                                DispatchQueue.main.async {
+                                    Utils.showBanner(in: self.view, type: .success, text: LocalizedStrings.mixerSetupCompleted)
+                                    let PrivacyViewVC = PrivacyViewController.instantiate(from: .Privacy)
+                                    PrivacyViewVC.wallet = self.wallet
+                                    self.navigationController?.pushViewController(PrivacyViewVC, animated: true)
+                                    
+                                }
+                            } catch let error {
+                                print("sign error:", error.localizedDescription)
+                                Utils.showBanner(in: self.view, type: .error, text: error.localizedDescription)
+                            }
+                        }
+                    } else {
+                        self.autoSetupByPinPass()
+                    }
+                })
+            } else {
+                self.autoSetupByPinPass()
+            }
+        }
+    }
+    
+    func autoSetupByPinPass() {
+        Security.spending(initialSecurityType: SpendingPinOrPassword.securityType(for: self.wallet.id_))
+            .with(prompt: LocalizedStrings.confirmToCreateMixer)
+            .with(submitBtnText: LocalizedStrings.confirm)
+            .requestCurrentCode(sender: self) { spendingCode, _, dialogDelegate in
+                
+                DispatchQueue.global(qos: .userInitiated).async {
+                    do {
+                        try self.wallet.createMixerAccounts(GlobalConstants.Strings.MIXED, unmixedAccount: GlobalConstants.Strings.UNMIXED, privPass: spendingCode)
+                        WalletLoader.shared.multiWallet.setBoolConfigValueForKey("has_setup_privacy", value: true)
+                        
+                        DispatchQueue.main.async {
+                            dialogDelegate?.dismissDialog()
+                            
+                            Utils.showBanner(in: self.view, type: .success, text: LocalizedStrings.mixerSetupCompleted)
+                            
+                            let PrivacyViewVC = PrivacyViewController.instantiate(from: .Privacy)
+                            PrivacyViewVC.wallet = self.wallet
+                            self.navigationController?.pushViewController(PrivacyViewVC, animated: true)
+                            
+                        }
+                    } catch let error {
+                        DispatchQueue.main.async {
+                            var errorMessage = error.localizedDescription
+                            if error.isInvalidPassphraseError {
+                                errorMessage = SpendingPinOrPassword.invalidSecurityCodeMessage(for: self.wallet.id_)
+                            }
+                            Utils.showBanner(in: self.view, type: .error, text: errorMessage)
+                            dialogDelegate?.displayError(errorMessage: errorMessage)
+                        }
+                    }
+                }
+            }
     }
 }


### PR DESCRIPTION
Resolve #893 

While trying to setup mixer for a wallet, if the wallet has just one account, the "set up needed accounts" page is skipped, and the user is redirected to auto setup.
This is because the "set up needed accounts" page provides the user with the option to use manual mixer, which isn't possible which just one account in a wallet.

**Screenshot**
<img width="300" src="https://user-images.githubusercontent.com/19331824/165776693-ecbe9060-843b-4b86-a7f4-0e374cd38960.png" style="max-width: 100%;">
